### PR TITLE
Fix Emoji#==

### DIFF
--- a/lib/discordrb/data/emoji.rb
+++ b/lib/discordrb/data/emoji.rb
@@ -30,6 +30,16 @@ module Discordrb
       process_roles(data['roles']) if server
     end
 
+    # ID or name based comparison
+    def ==(other)
+      return Discordrb.id_compare(@id, other) if @id
+      return false unless other.is_a? Emoji
+
+      name == other.name
+    end
+
+    alias_method :eql?, :==
+
     # @return [String] the layout to mention it (or have it used) in a message
     def mention
       "<#{'a' if animated}:#{name}:#{id}>"


### PR DESCRIPTION
# Summary

## Changed
In Emoji#==, when id is nil, it changed so that it compares by id, type and name.

## Fixed
In Emoji#==. when id is nil, fix to prevent `NoMethodError`.

## Compare before and after

```ruby
user_defined_emoji
#=> <Emoji name=blueputit id=440166774525394955 animated=false>
discord_default_emoji
#=> <Emoji name=👍 id= animated=false>

# before

discord_default_emoji == discord_default_emoji
#=> true
discord_default_emoji == user_defined_emoji
#=> false
discord_default_emoji == user_defined_emoji
# #<NoMethodError: undefined method `resolve_id' for nil:NilClass>
discord_default_emoji == discord_default_emoji
# #<NoMethodError: undefined method `resolve_id' for nil:NilClass>


# after

user_defined_emoji == user_defined_emoji
#=> true
user_defined_emoji == discord_default_emoji
#=> false
discord_default_emoji == user_defined_emoji
#=> false
discord_default_emoji == discord_default_emoji
#=> true
```
