### PR TITLE
Fix VoiceStateUpdateEvent handler matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **(breaking change)** `Message#reactions` is changed to return an Array instead of a hash, fixing reactions with the same `name` value from being discarded (#[593](https://github.com/meew0/discordrb/pull/596))
 - `Channel#nsfw=` correctly forwards updated value to the API ([#628](https://github.com/meew0/discordrb/pull/628))
 - `Emoji#==` works correctly for unicode emoji ([#590](https://github.com/discordrb/discordrb/pull/590), thanks @soukouki)
+- Attribute matching for voice state update events ([#625](https://github.com/discordrb/discordrb/pull/625), thanks @swarley) 
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/events/voice_state_update.rb
+++ b/lib/discordrb/events/voice_state_update.rb
@@ -47,28 +47,28 @@ module Discordrb::Events
                end
         end,
         matches_all(@attributes[:mute], event.mute) do |a, e|
-          a == if a.is_a?(TrueClass) || a.is_a?(FalseClass)
+          a == if a.is_a? String
                  e.to_s
                else
                  e
                end
         end,
         matches_all(@attributes[:deaf], event.deaf) do |a, e|
-          a == if a.is_a?(TrueClass) || a.is_a?(FalseClass)
+          a == if a.is_a? String
                  e.to_s
                else
                  e
                end
         end,
         matches_all(@attributes[:self_mute], event.self_mute) do |a, e|
-          a == if a.is_a?(TrueClass) || a.is_a?(FalseClass)
+          a == if a.is_a? String
                  e.to_s
                else
                  e
                end
         end,
         matches_all(@attributes[:self_deaf], event.self_deaf) do |a, e|
-          a == if a.is_a?(TrueClass) || a.is_a?(FalseClass)
+          a == if a.is_a? String
                  e.to_s
                else
                  e


### PR DESCRIPTION
# Summary

~~Remove unused accessor, clean up code, and~~ fix logic in handler matching.

## ~~Removed~~

~~Removed the accessor referencing `@token` in `VoiceStateUpdateEvent`.~~

## Fixed

`VoiceStateUpdateEventHandler#matches?` - Change matching that was previously using inappropriate logic.
