### PR TITLE
Update RuboCop and rbnacl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Give up reconnecting after receiving a fatal close code ([#633](https://github.com/meew0/discordrb/pull/633))
 - Misc upgrades to RuboCop v0.68 ([#624](https://github.com/meew0/discordrb/pull/624), thanks @PanisSupraOmnia)
 - `await!` methods now accept a block to test for matching event conditions ([#635](https://github.com/discordrb/discordrb/pull/635), thanks @z64)
+- Dependency updates for RuboCop v0.74, redcarpet, and simplecov ([#636](https://github.com/discordrb/discordrb/pull/636), thanks @PanisSupraOmnia)
 
 ### Fixed
 

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -35,11 +35,11 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.4.0' # YARD markdown formatting
+  spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.68.0'
+  spec.add_development_dependency 'rubocop', '~> 0.74.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
-  spec.add_development_dependency 'simplecov', '~> 0.16.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
 end


### PR DESCRIPTION
# Summary

RuboCop updates have so far been gentle, giving us no new warnings. Rbnacl also was updated, and while it's a new major version it isn't breaking for us because all it did was drop Ruby 2.2 support.

---

## Changed

- Updated RuboCop
- Updated rbnacl
