### PR TITLE
Add #create_webhook method to create a webhook in a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Channel#news?`, `Channel#store?` ([#618](https://github.com/meew0/discordrb/pull/618), thanks @swarley)
 - `Server#bot_members`, `Server#non_bot_members` ([#626](https://github.com/meew0/discordrb/pull/626), thanks @flutterflies)
 - `API.get_gateway_bot` ([#632](https://github.com/meew0/discordrb/pull/632))
+- `Channel#create_webhook` ([#637](https://github.com/discordrb/discordrb/pull/637), thanks @Chew)
 
 ### Changed
 

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -704,7 +704,8 @@ module Discordrb
     # @param reason [String] the reason why this happened, for the audit logs
     # @return [Webhook] the instantiated webhook.
     def create_webhook(name, avatar = nil, reason = nil)
-      raise 'Tried to create a webhook in a non-server channel' unless server
+      raise ArgumentError, 'Tried to create a webhook in a non-server channel' unless server
+      raise ArgumentError, 'Tried to create a webhook in a non-text channel' unless text_channel?
 
       hook = API::Channel.create_webhook(@bot.token, @id, name, avatar, reason)
       Webhook.new(JSON.parse(hook), @bot)

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -700,15 +700,15 @@ module Discordrb
 
     # Creates a webhook in this channel
     # @param name [String] the default name of this webhook.
-    # @param avatar [String] the default avatar URL to give this hook
-    # @param reason [String] the reason why this happened, for the audit logs
-    # @return [Webhook] the instantiated webhook.
+    # @param avatar [String] the default avatar URL to give this webhook.
+    # @param reason [String] the reason for the webhook creation.
+    # @return [Webhook] the created webhook.
     def create_webhook(name, avatar = nil, reason = nil)
       raise ArgumentError, 'Tried to create a webhook in a non-server channel' unless server
       raise ArgumentError, 'Tried to create a webhook in a non-text channel' unless text_channel?
 
-      hook = API::Channel.create_webhook(@bot.token, @id, name, avatar, reason)
-      Webhook.new(JSON.parse(hook), @bot)
+      response = API::Channel.create_webhook(@bot.token, @id, name, avatar, reason)
+      Webhook.new(JSON.parse(response), @bot)
     end
 
     # Requests a list of Webhooks on the channel.

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -698,6 +698,18 @@ module Discordrb
 
     alias_method :leave, :leave_group
 
+    # Creates a webhook in this channel
+    # @param name [String] the default name of this webhook.
+    # @param avatar [String] the default avatar URL to give this hook
+    # @param reason [String] the reason why this happened, for the audit logs
+    # @return [Webhook] the instantiated webhook.
+    def create_webhook(name, avatar = nil, reason = nil)
+      raise 'Tried to create a webhook in a non-server channel' unless server
+
+      hook = API::Channel.create_webhook(@bot.token, @id, name, avatar, reason)
+      Webhook.new(JSON.parse(hook), @bot)
+    end
+
     # Requests a list of Webhooks on the channel.
     # @return [Array<Webhook>] webhooks on the channel.
     def webhooks

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -702,6 +702,7 @@ module Discordrb
     # @param name [String] the default name of this webhook.
     # @param avatar [String] the default avatar URL to give this webhook.
     # @param reason [String] the reason for the webhook creation.
+    # @raise [ArgumentError] if the channel isn't a text channel in a server.
     # @return [Webhook] the created webhook.
     def create_webhook(name, avatar = nil, reason = nil)
       raise ArgumentError, 'Tried to create a webhook in a non-server channel' unless server


### PR DESCRIPTION
# Summary

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

When I was making webhooks for a channel, I found there's no easy way to do this. So, using the power of my somewhat limited Ruby knowledge (help me out here), I was able to figure out how to do it! So, I wrote this method. It returns a Webhook object.

![image](https://user-images.githubusercontent.com/8278263/59524017-6a3bfc00-8e98-11e9-8d9c-bab53a48cee2.png)

The method takes in 3 parameters. 1 required (*name* of the webhook), 2 optional (*avatar* of the webhook, and *reason* for adding it for the Audit Log)

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added

* #create_webhook method to the Channel object.
