### PR TITLE
Update Server class to support Nitro Boost features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **(breaking change)** Removed `no_sync` argument in `Bot#stop` as part of a refactor that removes Ruby 2.3 compatibility ([#652](https://github.com/discordrb/discordrb/pull/652), thanks @PanisSupraOmnia)
 - Return `rest-client` dependency to `>= 2.0.0` since `2.1.0` is now released ([#654](https://github.com/discordrb/discordrb/pull/654), thanks @ali-l)
 - Added Bit for "Streaming" permission ([#660](https://github.com/discordrb/discordrb/pull/660), thanks @NCPlayz)
+- Methods for Nitro boosting related information ([#638](https://github.com/discordrb/discordrb/pull/638), thanks @Chew)
 
 ### Fixed
 

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -199,6 +199,11 @@ module Discordrb::API
     "#{cdn_url}/splashes/#{server_id}/#{splash_id}.#{format}"
   end
 
+  # Make a banner URL from server and banner IDs
+  def banner_url(server_id, banner_id, format = 'webp')
+    "#{cdn_url}/banners/#{server_id}/#{banner_id}.#{format}"
+  end
+
   # Make an emoji icon URL from emoji ID
   def emoji_icon_url(emoji_id, format = 'webp')
     "#{cdn_url}/emojis/#{emoji_id}.#{format}"

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -885,6 +885,7 @@ module Discordrb
       member = server.member(data['user']['id'].to_i)
       member.update_roles(data['roles'])
       member.update_nick(data['nick'])
+      member.update_boosting_since(data['premium_since'])
     end
 
     # Internal handler for GUILD_MEMBER_DELETE

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -251,6 +251,13 @@ module Discordrb
       @nick = nick
     end
 
+    # Update this member's boosting timestamp
+    # @note For internal user only.
+    # @!visibility private
+    def update_boosting_since(time)
+      @boosting_since = time
+    end
+
     include PermissionCalculator
 
     # Overwriting inspect for debug purposes

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -77,7 +77,7 @@ module Discordrb
 
     # @return [true, false] if this user is a Nitro Booster of this server.
     def boosting?
-      !@premium_since.nil?
+      !@boosting_since.nil?
     end
 
     # @return [true, false] whether this member is the server owner.

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -7,8 +7,7 @@ module Discordrb
     attr_reader :joined_at
 
     # @return [Time, nil] when this member boosted this server, `nil` if they haven't.
-    attr_reader :premium_since
-    alias_method :boosting_since, :premium_since
+    attr_reader :boosting_since
 
     # @return [String, nil] the nickname this member has, or `nil` if it has none.
     attr_reader :nick
@@ -73,10 +72,10 @@ module Discordrb
 
       @nick = data['nick']
       @joined_at = data['joined_at'] ? Time.parse(data['joined_at']) : nil
-      @premium_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
+      @boosting_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
     end
 
-    # @return [true, false] if this user is a Nitro Booster.
+    # @return [true, false] if this user is a Nitro Booster of this server.
     def boosting?
       !@premium_since.nil?
     end

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -6,6 +6,10 @@ module Discordrb
     # @return [Time] when this member joined the server.
     attr_reader :joined_at
 
+    # @return [Time, nil] when this member boosted this server, `nil` if they haven't.
+    attr_reader :premium_since
+    alias_method :boosting_since, :premium_since
+
     # @return [String, nil] the nickname this member has, or `nil` if it has none.
     attr_reader :nick
     alias_method :nickname, :nick
@@ -69,6 +73,12 @@ module Discordrb
 
       @nick = data['nick']
       @joined_at = data['joined_at'] ? Time.parse(data['joined_at']) : nil
+      @premium_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
+    end
+
+    # @return [true, false] if this user is a Nitro Booster.
+    def boosting?
+      !@premium_since.nil?
     end
 
     # @return [true, false] whether this member is the server owner.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -56,6 +56,14 @@ module Discordrb
     # @return [Hash<Integer => VoiceState>] the hash (user ID => voice state) of voice states of members on this server
     attr_reader :voice_states
 
+    # The server's amount of Nitro boosters.
+    # @return [Integer] the amount of boosters, 0 if no one has boosted.
+    attr_reader :booster_count
+
+    # The server's Nitro boost level.
+    # @return [Integer] the boost level, 0 if no level.
+    attr_reader :boost_level
+
     # @!visibility private
     def initialize(data, bot, exists = true)
       @bot = bot
@@ -381,14 +389,6 @@ module Discordrb
 
       API.banner_url(@id, @banner_id)
     end
-
-    # The server's amount of Nitro boosters.
-    # @return [Integer] the amount of boosters, 0 if no one has boosted.
-    attr_reader :booster_count
-
-    # The server's Nitro boost level.
-    # @return [Integer] the boost level, 0 if no level.
-    attr_reader :boost_level
 
     # Adds a role to the role cache
     # @note For internal use only

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -386,15 +386,11 @@ module Discordrb
 
     # The server's amount of Nitro boosters.
     # @return [Integer] the amount of boosters, 0 if no one has boosted.
-    def boosters
-      @boosters
-    end
+    attr_reader :boosters
 
     # The server's Nitro boost level.
     # @return [Integer] the boost level, 0 if no level.
-    def level
-      @level
-    end
+    attr_reader :level
 
     alias_method :boost_level, :level
 
@@ -588,15 +584,15 @@ module Discordrb
     def max_emoji
       case @level
       when 0
-        return 50
+        50
       when 1
-        return 100
+        100
       when 2
-        return 150
+        150
       when 3
-        return 250
+        250
       else
-        return 50
+        50
       end
     end
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -95,7 +95,7 @@ module Discordrb
       # Only get the owner of the server actually exists (i.e. not for ServerDeleteEvent)
       @owner = member(@owner_id) if exists
 
-      @booster_count = data['premium_subscription_count']
+      @booster_count = data['premium_subscription_count'] || 0
       @boost_level = data['premium_tier']
     end
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -377,7 +377,7 @@ module Discordrb
     #   `nil` if there is no banner image.
     def banner_url
       banner_id if @banner_id.nil?
-      return unless @banner_id
+      return unless banner_id
 
       API.banner_url(@id, @banner_id)
     end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -87,9 +87,8 @@ module Discordrb
       # Only get the owner of the server actually exists (i.e. not for ServerDeleteEvent)
       @owner = member(@owner_id) if exists
 
-      # Nitro Server Boosting related variables
-      @boosters = data['premium_subscription_count']
-      @level = data['premium_tier']
+      @booster_count = data['premium_subscription_count']
+      @boost_level = data['premium_tier']
     end
 
     # The default channel is the text channel on this server with the highest position
@@ -369,30 +368,27 @@ module Discordrb
       API.splash_url(@id, @splash_id)
     end
 
-    # The banner is shown on partnered, verified, or servers with a boost level of 2 or higher.
     # @return [String] the hexadecimal ID used to identify this server's banner image, shown by the server name.
     def banner_id
       @banner_id ||= JSON.parse(API::Server.resolve(@bot.token, @id))['banner']
     end
 
-    # @return [String, nil] the banner image URL for the server's banner image.
+    # @return [String, nil] the banner image URL for the server's banner image, or
     #   `nil` if there is no banner image.
     def banner_url
       banner_id if @banner_id.nil?
-      return nil unless @banner_id
+      return unless @banner_id
 
       API.banner_url(@id, @banner_id)
     end
 
     # The server's amount of Nitro boosters.
     # @return [Integer] the amount of boosters, 0 if no one has boosted.
-    attr_reader :boosters
+    attr_reader :booster_count
 
     # The server's Nitro boost level.
     # @return [Integer] the boost level, 0 if no level.
-    attr_reader :level
-
-    alias_method :boost_level, :level
+    attr_reader :boost_level
 
     # Adds a role to the role cache
     # @note For internal use only
@@ -579,7 +575,7 @@ module Discordrb
       @emoji[new_emoji.id] = new_emoji
     end
 
-    # The amount of emoji the server can have, based on Nitro Boost Level.
+    # The amount of emoji the server can have, based on its current Nitro Boost Level.
     # @return [Integer] the max amount of emoji
     def max_emoji
       case @level

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -583,8 +583,6 @@ module Discordrb
     # @return [Integer] the max amount of emoji
     def max_emoji
       case @level
-      when 0
-        50
       when 1
         100
       when 2


### PR DESCRIPTION
# Summary

This updates the Server class with the new Nitro Server Boost features.

## Added

* `API.banner_url` method. Similar to the `API.splash_url` method, this gets the banner URL of a server by ID and hash.
* `Server#banner_id` method. Gets the CDN ID of the server's banner ID.
* `Server#banner_url` method. Gets the url of the server's banner.
* `Server#boosters` method. Gets the amount of Nitro Boosters this server has.
* `Server#level` method. Gets the server's nitro boost level.
* `Server#boost_level` alias method. Alias of new method `Server#level`.
* `Server#max_emoji` method. Returns the maximum amount of emoji this server has.

As of commit 85384f50345

* `Member#boosting?` method. Checks to see if the member is boosting the server.
* `Member#boosting_since` method. Returns when the member started boosting, nil if they aren't boosting.

## Changed