### PR TITLE
Remove rbnacl gem dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+  - sudo apt-get install libsodium-dev
 script:
   - bundle exec rspec spec
   - bundle exec rubocop -c .rubocop.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Emoji#==` works correctly for unicode emoji ([#590](https://github.com/discordrb/discordrb/pull/590), thanks @soukouki)
 - Attribute matching for voice state update events ([#625](https://github.com/discordrb/discordrb/pull/625), thanks @swarley) 
 
+### Removed
+
+- Removed dependency on `rbnacl` in favor of our own FFI bindings ([#641](https://github.com/discordrb/discordrb/pull/641), thanks @z64)
+
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0
 

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'rbnacl', '~> 6.0'
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -311,7 +311,7 @@ module Discordrb
     # connected to voice, the existing connection will be terminated - you don't have to call
     # {Discordrb::Voice::VoiceBot#destroy} before calling this method.
     # @param chan [Channel, String, Integer] The voice channel, or its ID, to connect to.
-    # @param encrypted [true, false] Whether voice communication should be encrypted using RbNaCl's SecretBox
+    # @param encrypted [true, false] Whether voice communication should be encrypted using
     #   (uses an XSalsa20 stream cipher for encryption and Poly1305 for authentication)
     # @return [Voice::VoiceBot] the initialized bot over which audio data can then be sent.
     def voice_connect(chan, encrypted = true)

--- a/lib/discordrb/voice/sodium.rb
+++ b/lib/discordrb/voice/sodium.rb
@@ -21,8 +21,8 @@ module Discordrb::Voice
   # Utility class for interacting with required `xsalsa20poly1305` functions for voice transmission
   # @!visibility private
   class SecretBox
-    # Exception raised when a key with invalid length is used
-    class KeyLengthError < RuntimeError
+    # Exception raised when a key or nonce with invalid length is used
+    class LengthError < RuntimeError
     end
 
     # Exception raised when encryption or decryption fails
@@ -43,7 +43,7 @@ module Discordrb::Voice
 
     # @param key [String] Crypto key of length {KEY_LENGTH}
     def initialize(key)
-      raise(KeyLengthError, 'Key length') if key.bytesize != KEY_LENGTH
+      raise(LengthError, 'Key length') if key.bytesize != KEY_LENGTH
 
       @key = key
     end
@@ -52,6 +52,8 @@ module Discordrb::Voice
     # @param nonce [String] encryption nonce for this message
     # @param message [String] message to be encrypted
     def box(nonce, message)
+      raise(LengthError, 'Nonce length') if nonce.bytesize != NONCE_BYTES
+
       message_padded = prepend_zeroes(ZERO_BYTES, message)
       buffer = zero_string(message_padded.bytesize)
 
@@ -65,6 +67,8 @@ module Discordrb::Voice
     # @param nonce [String] encryption nonce for this ciphertext
     # @param ciphertext [String] ciphertext to decrypt
     def open(nonce, ciphertext)
+      raise(LengthError, 'Nonce length') if nonce.bytesize != NONCE_BYTES
+
       ct_padded = prepend_zeroes(BOX_ZERO_BYTES, ciphertext)
       buffer = zero_string(ct_padded.bytesize)
 

--- a/lib/discordrb/voice/sodium.rb
+++ b/lib/discordrb/voice/sodium.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Discordrb::Voice
+  # @!visibility private
+  module Sodium
+    extend FFI::Library
+
+    ffi_lib(['sodium', 'libsodium.so.18', 'libsodium.so.23'])
+
+    # Encryption & decryption
+    attach_function(:crypto_secretbox_xsalsa20poly1305, %i[pointer pointer ulong_long pointer pointer], :int)
+    attach_function(:crypto_secretbox_xsalsa20poly1305_open, %i[pointer pointer ulong_long pointer pointer], :int)
+
+    # Constants
+    attach_function(:crypto_secretbox_xsalsa20poly1305_keybytes, [], :size_t)
+    attach_function(:crypto_secretbox_xsalsa20poly1305_noncebytes, [], :size_t)
+    attach_function(:crypto_secretbox_xsalsa20poly1305_zerobytes, [], :size_t)
+    attach_function(:crypto_secretbox_xsalsa20poly1305_boxzerobytes, [], :size_t)
+  end
+
+  # Utility class for interacting with required `xsalsa20poly1305` functions for voice transmission
+  # @!visibility private
+  class SecretBox
+    # Exception raised when a key with invalid length is used
+    class KeyLengthError < RuntimeError
+    end
+
+    # Exception raised when encryption or decryption fails
+    class CryptoError < RuntimeError
+    end
+
+    # Required key length
+    KEY_LENGTH = Sodium.crypto_secretbox_xsalsa20poly1305_keybytes
+
+    # Required nonce length
+    NONCE_BYTES = Sodium.crypto_secretbox_xsalsa20poly1305_noncebytes
+
+    # Zero byte padding for encryption
+    ZERO_BYTES = Sodium.crypto_secretbox_xsalsa20poly1305_zerobytes
+
+    # Zero byte padding for decryption
+    BOX_ZERO_BYTES = Sodium.crypto_secretbox_xsalsa20poly1305_boxzerobytes
+
+    # @param key [String] Crypto key of length {KEY_LENGTH}
+    def initialize(key)
+      raise(KeyLengthError, 'Key length') if key.bytesize != KEY_LENGTH
+
+      @key = key
+    end
+
+    # Encrypts a message using this box's key
+    # @param nonce [String] encryption nonce for this message
+    # @param message [String] message to be encrypted
+    def box(nonce, message)
+      message_padded = prepend_zeroes(ZERO_BYTES, message)
+      buffer = zero_string(message_padded.bytesize)
+
+      success = Sodium.crypto_secretbox_xsalsa20poly1305(buffer, message_padded, message_padded.bytesize, nonce, @key)
+      raise(CryptoError, "Encryption failed (#{success})") unless success.zero?
+
+      remove_zeroes(BOX_ZERO_BYTES, buffer)
+    end
+
+    # Decrypts the given ciphertext using this box's key
+    # @param nonce [String] encryption nonce for this ciphertext
+    # @param ciphertext [String] ciphertext to decrypt
+    def open(nonce, ciphertext)
+      ct_padded = prepend_zeroes(BOX_ZERO_BYTES, ciphertext)
+      buffer = zero_string(ct_padded.bytesize)
+
+      success = Sodium.crypto_secretbox_xsalsa20poly1305(buffer, ct_padded, ct_padded.bytesize, nonce, @key)
+      raise(CryptoError, "Decryption failed (#{success})") unless success.zero?
+
+      remove_zeroes(ZERO_BYTES, buffer)
+    end
+
+    private
+
+    def zero_string(size)
+      str = "\0" * size
+      str.force_encoding('ASCII-8BIT') if str.respond_to?(:force_encoding)
+    end
+
+    def prepend_zeroes(size, string)
+      zero_string(size) + string
+    end
+
+    def remove_zeroes(size, string)
+      string.slice!(size, string.bytesize - size)
+    end
+  end
+end

--- a/spec/sodium_spec.rb
+++ b/spec/sodium_spec.rb
@@ -21,6 +21,22 @@ describe Discordrb::Voice::SecretBox do
 
   it 'raises on invalid key length' do
     key = rand_bytes(Discordrb::Voice::SecretBox::KEY_LENGTH - 1)
-    expect { Discordrb::Voice::SecretBox.new(key) }.to raise_error(Discordrb::Voice::SecretBox::KeyLengthError)
+    expect { Discordrb::Voice::SecretBox.new(key) }.to raise_error(Discordrb::Voice::SecretBox::LengthError)
+  end
+
+  describe '#box' do
+    it 'raises on invalid nonce length' do
+      key = rand_bytes(Discordrb::Voice::SecretBox::KEY_LENGTH)
+      nonce = rand_bytes(Discordrb::Voice::SecretBox::NONCE_BYTES - 1)
+      expect { Discordrb::Voice::SecretBox.new(key).box(nonce, '') }.to raise_error(Discordrb::Voice::SecretBox::LengthError)
+    end
+  end
+
+  describe '#open' do
+    it 'raises on invalid nonce length' do
+      key = rand_bytes(Discordrb::Voice::SecretBox::KEY_LENGTH)
+      nonce = rand_bytes(Discordrb::Voice::SecretBox::NONCE_BYTES - 1)
+      expect { Discordrb::Voice::SecretBox.new(key).open(nonce, '') }.to raise_error(Discordrb::Voice::SecretBox::LengthError)
+    end
   end
 end

--- a/spec/sodium_spec.rb
+++ b/spec/sodium_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'discordrb/voice/sodium'
+
+describe Discordrb::Voice::SecretBox do
+  def rand_bytes(size)
+    bytes = Array.new(size) { rand(256) }
+    bytes.pack('C*')
+  end
+
+  it 'encrypts round trip' do
+    key = rand_bytes(Discordrb::Voice::SecretBox::KEY_LENGTH)
+    nonce = rand_bytes(Discordrb::Voice::SecretBox::NONCE_BYTES)
+    message = rand_bytes(20)
+
+    secret_box = Discordrb::Voice::SecretBox.new(key)
+    ct = secret_box.box(nonce, message)
+    pt = secret_box.open(nonce, ct)
+    expect(pt).to eq message
+  end
+
+  it 'raises on invalid key length' do
+    key = rand_bytes(Discordrb::Voice::SecretBox::KEY_LENGTH - 1)
+    expect { Discordrb::Voice::SecretBox.new(key) }.to raise_error(Discordrb::Voice::SecretBox::KeyLengthError)
+  end
+end


### PR DESCRIPTION
We only require two functions from `rbnacl`'s binding to `libsodium` (technically only one, because we don't support voice receiving yet). This drops the `rbnacl` dependency in favor of rolling our own binding using `ffi`, which is a minimal amount of code.

As a result, this should no longer conflict with any other gem's loading mechanism, as the loading is entirely internal now.

Closes #639 

- [ ] Remove reference to `rbnacl` in Wiki page after merge