### PR TITLE
Return `nil` on 204 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Emoji#==` works correctly for unicode emoji ([#590](https://github.com/discordrb/discordrb/pull/590), thanks @soukouki)
 - Attribute matching for voice state update events ([#625](https://github.com/discordrb/discordrb/pull/625), thanks @swarley) 
 - `Emoji#to_reaction` works correctly for unicode emoji ([#642](https://github.com/discordrb/discordrb/pull/642), thanks @z64)
+- `Server#add_member_using_token` returns `nil` when user is already a member ([#643](https://github.com/discordrb/discordrb/pull/643), thanks @swarley)
 
 ### Removed
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -271,12 +271,14 @@ module Discordrb
     # @param roles [Role, Array<Role, String, Integer>] the role (or roles) to give this member upon joining
     # @param deaf [true, false] whether this member will be server deafened upon joining
     # @param mute [true, false] whether this member will be server muted upon joining
-    # @return [Member] the created member
+    # @return [Member, `nil`] the created member, or `nil` if the user is already a member of this server.
     def add_member_using_token(user, access_token, nick: nil, roles: [], deaf: false, mute: false)
       user_id = user.resolve_id
       roles = roles.is_a?(Array) ? roles.map(&:resolve_id) : [roles.resolve_id]
-      response = JSON.parse(API::Server.add_member(@bot.token, @id, user_id, access_token, nick, roles, deaf, mute))
-      add_member Member.new(response, self, @bot)
+      response = API::Server.add_member(@bot.token, @id, user_id, access_token, nick, roles, deaf, mute)
+      return nil if response.empty?
+
+      add_member Member.new(JSON.parse(response), self, @bot)
     end
 
     # Returns the amount of members that are candidates for pruning

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -271,7 +271,7 @@ module Discordrb
     # @param roles [Role, Array<Role, String, Integer>] the role (or roles) to give this member upon joining
     # @param deaf [true, false] whether this member will be server deafened upon joining
     # @param mute [true, false] whether this member will be server muted upon joining
-    # @return [Member, `nil`] the created member, or `nil` if the user is already a member of this server.
+    # @return [Member, nil] the created member, or `nil` if the user is already a member of this server.
     def add_member_using_token(user, access_token, nick: nil, roles: [], deaf: false, mute: false)
       user_id = user.resolve_id
       roles = roles.is_a?(Array) ? roles.map(&:resolve_id) : [roles.resolve_id]


### PR DESCRIPTION
# Summary

Currently, `Server#add_member_using_token` will raise a JSON parsing error if you attempt to add a user that is already on the server.

This is because in this case Discord returns a 204 response code with an empty body that we do not check for.

This change adds a check for an empty response body and returns `nil` if that's the case.

----------------------------------

## Changed
`Server#add_member_using_token` - Now returns `nil` when the user is already a member of the server.
