### PR TITLE
Update VoiceUDP to use `ip` in `READY` payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Misc upgrades to RuboCop v0.68 ([#624](https://github.com/meew0/discordrb/pull/624), thanks @PanisSupraOmnia)
 - `await!` methods now accept a block to test for matching event conditions ([#635](https://github.com/discordrb/discordrb/pull/635), thanks @z64)
 - Dependency updates for RuboCop v0.74, redcarpet, and simplecov ([#636](https://github.com/discordrb/discordrb/pull/636), thanks @PanisSupraOmnia)
+- Update voice logic to connect to the IP address from READY ([#644](https://github.com/discordrb/discordrb/pull/644), thanks @swarley)
 
 ### Fixed
 

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -43,16 +43,12 @@ module Discordrb::Voice
     end
 
     # Initializes the UDP socket with data obtained from opcode 2.
-    # @param endpoint [String] The voice endpoint to connect to.
+    # @param ip [String] The IP address to connect to.
     # @param port [Integer] The port to connect to.
     # @param ssrc [Integer] The Super Secret Relay Code (SSRC). Discord uses this to identify different voice users
     #   on the same endpoint.
-    def connect(endpoint, port, ssrc)
-      @endpoint = endpoint
-      @endpoint = @endpoint[6..-1] if @endpoint.start_with? 'wss://'
-      @endpoint = @endpoint.gsub(':80', '') # The endpoint may contain a port, we don't want that
-      @endpoint = Resolv.getaddress @endpoint
-
+    def connect(ip, port, ssrc)
+      @ip = ip
       @port = port
       @ssrc = ssrc
     end
@@ -110,7 +106,7 @@ module Discordrb::Voice
     end
 
     def send_packet(packet)
-      @socket.send(packet, 0, @endpoint, @port)
+      @socket.send(packet, 0, @ip, @port)
     end
   end
 
@@ -224,7 +220,7 @@ module Discordrb::Voice
         @port = @ws_data['port']
         @udp_mode = mode
 
-        @udp.connect(@endpoint, @port, @ssrc)
+        @udp.connect(@ws_data['ip'], @port, @ssrc)
         @udp.send_discovery
       when 4
         # Opcode 4 sends the secret key used for encryption

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'websocket-client-simple'
-require 'resolv'
 require 'socket'
 require 'json'
 


### PR DESCRIPTION
# Summary

Removes usage of `endpoint` within `VoiceUDP` to comply with the upcoming voice changes. These changes have been tested to work locally.

---

## Changed
`VoiceUDP#connect`
`VoiceUDP#send_packet` 
`VoiceWS#websocket_message`

## Removed
All references to `endpoint` within `VoiceUDP`.
