### PR TITLE
Exclude the end value, to make more efficient code 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `await!` methods now accept a block to test for matching event conditions ([#635](https://github.com/discordrb/discordrb/pull/635), thanks @z64)
 - Dependency updates for RuboCop v0.74, redcarpet, and simplecov ([#636](https://github.com/discordrb/discordrb/pull/636), thanks @PanisSupraOmnia)
 - Update voice logic to connect to the IP address from READY ([#644](https://github.com/discordrb/discordrb/pull/644), thanks @swarley)
+- Refactored use of enumerable code in `Discordrb.split_message` ([#646](https://github.com/discordrb/discordrb/pull/646), thanks @piharpi)
 
 ### Fixed
 

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -40,7 +40,7 @@ module Discordrb
     #  [1, 2, 3],
     #  [1, 2, 3, 4]
     # ]
-    tri = [*0...lines.length].map { |i| lines.combination(i + 1).first }
+    tri = (0...lines.length).map { |i| lines.combination(i + 1).first }
 
     # Join the individual elements together to get an array of strings with consecutively more lines
     joined = tri.map(&:join)

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -40,7 +40,7 @@ module Discordrb
     #  [1, 2, 3],
     #  [1, 2, 3, 4]
     # ]
-    tri = [*0..(lines.length - 1)].map { |i| lines.combination(i + 1).first }
+    tri = [*0...(lines.length)].map { |i| lines.combination(i + 1).first }
 
     # Join the individual elements together to get an array of strings with consecutively more lines
     joined = tri.map(&:join)

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -40,7 +40,7 @@ module Discordrb
     #  [1, 2, 3],
     #  [1, 2, 3, 4]
     # ]
-    tri = [*0...(lines.length)].map { |i| lines.combination(i + 1).first }
+    tri = [*0...lines.length].map { |i| lines.combination(i + 1).first }
 
     # Join the individual elements together to get an array of strings with consecutively more lines
     joined = tri.map(&:join)


### PR DESCRIPTION
Clean up, using `...` range  to exclude the end value rather than `lines.length - 1` and `..`  end value inclusively.

I think this make more efficient than we reading with `(lines.lenght - 1)`