### PR TITLE
Clean up pre-2.4 code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependency updates for RuboCop v0.74, redcarpet, and simplecov ([#636](https://github.com/discordrb/discordrb/pull/636), thanks @PanisSupraOmnia)
 - Update voice logic to connect to the IP address from READY ([#644](https://github.com/discordrb/discordrb/pull/644), thanks @swarley)
 - Refactored use of enumerable code in `Discordrb.split_message` ([#646](https://github.com/discordrb/discordrb/pull/646), thanks @piharpi)
+- **(breaking change)** Removed `no_sync` argument in `Bot#stop` as part of a refactor that removes Ruby 2.3 compatibility ([#652](https://github.com/discordrb/discordrb/pull/652), thanks @PanisSupraOmnia)
 
 ### Fixed
 

--- a/lib/discordrb/events/raw.rb
+++ b/lib/discordrb/events/raw.rb
@@ -30,9 +30,7 @@ module Discordrb::Events
       [
         matches_all(@attributes[:type] || @attributes[:t], event.type) do |a, e|
           if a.is_a? Regexp
-            # 24: update to matches?
-            match = a.match(e)
-            match ? (e == match[0]) : false
+            a.match?(e)
           else
             e.to_s.casecmp(a.to_s).zero?
           end


### PR DESCRIPTION
# Summary

There were a couple spots that were missed when Ruby 2.3 support was dropped, this PR updates those spots. Theoretically the changes should also improve performance, but I haven't benchmarked and it's probably negligible.

---

## Fixed

- Use `Regexp#match?` when the `MatchData` isn't needed.
- Don't use a mutex for websocket sync because the Ruby bug that made it an issue was fixed in 2.4.