### PR TITLE
Parse Integer arguments in base 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attribute matching for voice state update events ([#625](https://github.com/discordrb/discordrb/pull/625), thanks @swarley) 
 - `Emoji#to_reaction` works correctly for unicode emoji ([#642](https://github.com/discordrb/discordrb/pull/642), thanks @z64)
 - `Server#add_member_using_token` returns `nil` when user is already a member ([#643](https://github.com/discordrb/discordrb/pull/643), thanks @swarley)
+- `CommandBot`'s `Integer` parser interprets all integers as base 10 ([#656](https://github.com/discordrb/discordrb/pull/656), thanks @joshleblanc)
 
 ### Removed
 

--- a/examples/prefix_proc.rb
+++ b/examples/prefix_proc.rb
@@ -55,8 +55,8 @@ bot.command(:roll, description: 'rolls some dice',
 
   # Check for valid input; make sure we actually got numbers and not words
   begin
-    number = Integer(number)
-    sides  = Integer(sides)
+    number = Integer(number, 10)
+    sides  = Integer(sides, 10)
   rescue ArgumentError
     next 'You must pass two *numbers*.. try: `roll 2d10`'
   end

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -249,7 +249,7 @@ module Discordrb::Commands
 
         if types[i] == Integer
           begin
-            Integer(arg)
+            Integer(arg, 10)
           rescue ArgumentError
             nil
           end


### PR DESCRIPTION
# Summary

The integer argument type doesn't parse strings into a base 10 integer. This pull request sets the radix on the parse.

Problem case:

You have a command that will delete a record from a database, based on ID. The command is "delete some_id". A user calls "delete 0066". The integer passed to the command will be `54`, because "0066" is an octal string for 54.

---

## Changed
 * command_bot.rb - Added radix to Integer(arg) call
* prefix_proc.rb - Added radix to both Integer calls
