### PR TITLE
Add stream permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored use of enumerable code in `Discordrb.split_message` ([#646](https://github.com/discordrb/discordrb/pull/646), thanks @piharpi)
 - **(breaking change)** Removed `no_sync` argument in `Bot#stop` as part of a refactor that removes Ruby 2.3 compatibility ([#652](https://github.com/discordrb/discordrb/pull/652), thanks @PanisSupraOmnia)
 - Return `rest-client` dependency to `>= 2.0.0` since `2.1.0` is now released ([#654](https://github.com/discordrb/discordrb/pull/654), thanks @ali-l)
+- Added Bit for "Streaming" permission ([#660](https://github.com/discordrb/discordrb/pull/660), thanks @NCPlayz)
 
 ### Fixed
 

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -16,7 +16,7 @@ module Discordrb
       6 => :add_reactions,         # 64
       7 => :view_audit_log,        # 128
       8 => :priority_speaker,      # 256
-      9 => :stream                 # 512
+      9 => :stream,                # 512
       10 => :read_messages,        # 1024
       11 => :send_messages,        # 2048
       12 => :send_tts_messages,    # 4096

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -16,7 +16,7 @@ module Discordrb
       6 => :add_reactions,         # 64
       7 => :view_audit_log,        # 128
       8 => :priority_speaker,      # 256
-      # 9                          # 512
+      9 => :stream                 # 512
       10 => :read_messages,        # 1024
       11 => :send_messages,        # 2048
       12 => :send_tts_messages,    # 4096


### PR DESCRIPTION
# Summary

Add the missing stream permission (9). 
This is mentioned in discordapp/discord-api-docs#918. `Permissions.stream` is for Discord's guild video feature. A reference can also be found in the Discord Datamining repo.

Previously, there was no bit assigned to 512.

---

## Added

- Declared `Permissions#stream` as 9.