### PR TITLE
Fix message split in #split_message

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -55,9 +55,15 @@ module Discordrb
     # If there is no space to logically split the message on in the message (No spaces at all), it stays the same, otherwise
     # cut string on index of the last space, and put everything after that space in the next index
     # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string
-    0.upto(ideal_ary.length-2) { |x| ideal_ary[x].rindex(/ /).nil? ? (ideal_ary[x] = ideal_ary[x])
-    : (ideal_ary[x], ideal_ary[x+1] = ideal_ary[x][0..ideal_ary[x].rindex(/ /)],
-    (ideal_ary[x][ideal_ary[x].rindex(/ /)..-1] + ideal_ary[x+1])) }
+
+    0.upto(ideal_ary.length-2) do |x|
+      if ideal_ary[x].rindex(/ /).nil? #if there is no space to break on, just leave it be
+        (ideal_ary[x] = ideal_ary[x])  #not the best way to do this, probably, but I don't personally know a better way
+      else
+        ideal_ary[x+1] = ideal_ary[x][ideal_ary[x].rindex(/ /)..-1] + ideal_ary[x+1] #shift the split bit from the string and move it one index up
+        ideal_ary[x] = ideal_ary[x][0..ideal_ary[x].rindex(/ /)] #split the string at the last space character
+      end
+    end
 
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -48,21 +48,9 @@ module Discordrb
     # Find the largest element that is still below the character limit, or if none such element exists return the first
     ideal = joined.max_by { |e| e.length > CHARACTER_LIMIT ? -1 : e.length }
 
-    # If it's still larger than the character limit (none was smaller than it) split it into slices with the length
-    # being the character limit, otherwise just return an array with one element
-    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.chars.each_slice(CHARACTER_LIMIT).map(&:join) : [ideal]
-
-    # If there is no space to logically split the message on in the message (No spaces at all), it stays the same, otherwise
-    # cut string on index of the last space, and put everything after that space in the next index
-    # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string
-
-    0.upto(ideal_ary.length-2) do |x|
-      index = ideal_ary[x].rindex(/\s/)
-      unless index.nil?
-        ideal_ary[x+1] = ideal_ary[x][index..-1] + ideal_ary[x+1] #shift the split bit from the string and move it one index up
-        ideal_ary[x] = ideal_ary[x][0..index] #split the string at the last space character
-      end
-    end
+    # If it's still larger than the character limit (none was smaller than it) split it into the largest chunk without
+    # cutting words apart, breaking on the nearest space within character limit, otherwise just return an array with one element
+    ideal_ary = ideal.length > 2000 ? ideal.split(/(.{,2000}\b+?)/).reject(&:empty?) : [ideal]
 
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -57,9 +57,10 @@ module Discordrb
     # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string
 
     0.upto(ideal_ary.length-2) do |x|
-      unless ideal_ary[x].rindex(/\s/).nil? 
-        ideal_ary[x+1] = ideal_ary[x][ideal_ary[x].rindex(/\s/)..-1] + ideal_ary[x+1] #shift the split bit from the string and move it one index up
-        ideal_ary[x] = ideal_ary[x][0..ideal_ary[x].rindex(/\s/)] #split the string at the last space character
+      index = ideal_ary[x].rindex(/\s/)
+      unless index.nil?
+        ideal_ary[x+1] = ideal_ary[x][index..-1] + ideal_ary[x+1] #shift the split bit from the string and move it one index up
+        ideal_ary[x] = ideal_ary[x][0..index] #split the string at the last space character
       end
     end
 

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -50,7 +50,7 @@ module Discordrb
 
     # If it's still larger than the character limit (none was smaller than it) split it into the largest chunk without
     # cutting words apart, breaking on the nearest space within character limit, otherwise just return an array with one element
-    ideal_ary = ideal.length > 2000 ? ideal.split(/(.{,2000}\b+?)/).reject(&:empty?) : [ideal]
+    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{,CHARACTER_LIMIT}\b+?)/).reject(&:empty?) : [ideal]
 
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -50,7 +50,7 @@ module Discordrb
 
     # If it's still larger than the character limit (none was smaller than it) split it into the largest chunk without
     # cutting words apart, breaking on the nearest space within character limit, otherwise just return an array with one element
-    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{,#{CHARACTER_LIMIT}}\b+?)/).reject(&:empty?) : [ideal]
+    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{,#{CHARACTER_LIMIT}}\b?+)/).reject(&:empty?) : [ideal]
 
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -54,8 +54,7 @@ module Discordrb
 
     # If there is no space to logically split the message on in the message (No spaces at all), it stays the same, otherwise
     # cut string on index of the last space, and put everything after that space in the next index
-    # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string, and also fix this messy ternary
-    # Note: also doesn't work past the first 4000 characters, obviously. Fix that./EDIT: FIXED
+    # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string
     0.upto(ideal_ary.length-2) { |x| ideal_ary[x].rindex(/ /).nil? ? (ideal_ary[x] = ideal_ary[x])
     : (ideal_ary[x], ideal_ary[x+1] = ideal_ary[x][0..ideal_ary[x].rindex(/ /)],
     (ideal_ary[x][ideal_ary[x].rindex(/ /)..-1] + ideal_ary[x+1])) }

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -57,11 +57,9 @@ module Discordrb
     # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string
 
     0.upto(ideal_ary.length-2) do |x|
-      if ideal_ary[x].rindex(/ /).nil? #if there is no space to break on, just leave it be
-        (ideal_ary[x] = ideal_ary[x])  #not the best way to do this, probably, but I don't personally know a better way
-      else
-        ideal_ary[x+1] = ideal_ary[x][ideal_ary[x].rindex(/ /)..-1] + ideal_ary[x+1] #shift the split bit from the string and move it one index up
-        ideal_ary[x] = ideal_ary[x][0..ideal_ary[x].rindex(/ /)] #split the string at the last space character
+      unless ideal_ary[x].rindex(/\s/).nil? 
+        ideal_ary[x+1] = ideal_ary[x][ideal_ary[x].rindex(/\s/)..-1] + ideal_ary[x+1] #shift the split bit from the string and move it one index up
+        ideal_ary[x] = ideal_ary[x][0..ideal_ary[x].rindex(/\s/)] #split the string at the last space character
       end
     end
 

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -50,7 +50,7 @@ module Discordrb
 
     # If it's still larger than the character limit (none was smaller than it) split it into the largest chunk without
     # cutting words apart, breaking on the nearest space within character limit, otherwise just return an array with one element
-    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{,CHARACTER_LIMIT}\b+?)/).reject(&:empty?) : [ideal]
+    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{,#{CHARACTER_LIMIT}}\b+?)/).reject(&:empty?) : [ideal]
 
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -52,6 +52,14 @@ module Discordrb
     # being the character limit, otherwise just return an array with one element
     ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.chars.each_slice(CHARACTER_LIMIT).map(&:join) : [ideal]
 
+    # If there is no space to logically split the message on in the message (No spaces at all), it stays the same, otherwise
+    # cut string on index of the last space, and put everything after that space in the next index
+    # Note: please find a way to be more inclusive of 'where to logical split message', /\b/ captures the end of string, and also fix this messy ternary
+    # Note: also doesn't work past the first 4000 characters, obviously. Fix that./EDIT: FIXED
+    0.upto(ideal_ary.length-2) { |x| ideal_ary[x].rindex(/ /).nil? ? (ideal_ary[x] = ideal_ary[x])
+    : (ideal_ary[x], ideal_ary[x+1] = ideal_ary[x][0..ideal_ary[x].rindex(/ /)],
+    (ideal_ary[x][ideal_ary[x].rindex(/ /)..-1] + ideal_ary[x+1])) }
+
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip
 

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -50,7 +50,7 @@ module Discordrb
 
     # If it's still larger than the character limit (none was smaller than it) split it into the largest chunk without
     # cutting words apart, breaking on the nearest space within character limit, otherwise just return an array with one element
-    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{,#{CHARACTER_LIMIT}}\b?+)/).reject(&:empty?) : [ideal]
+    ideal_ary = ideal.length > CHARACTER_LIMIT ? ideal.split(/(.{1,#{CHARACTER_LIMIT}}\b|.{1,#{CHARACTER_LIMIT}})/).reject(&:empty?) : [ideal]
 
     # Slice off the ideal part and strip newlines
     rest = msg[ideal.length..-1].strip

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -15,6 +15,9 @@ describe Discordrb do
     split = Discordrb.split_message('a' * 5234)
     expect(split).to eq(['a' * 2000, 'a' * 2000, 'a' * 1234])
 
+    split_on_space = Discordrb.split_message('a' * 1990 + ' ' + 'b' * 2000)
+    expect(split_on_space).to eq(['a' * 1990 + ' ', 'b' * 2000])
+
     # regression test
     # there had been an issue where this would have raised an error,
     # and (if it hadn't raised) produced incorrect results


### PR DESCRIPTION
# Summary

<!---
  #split_message chopped words and links in half, now it shouldn't
--->

---

<!---
  Only works if there's spaces in the text of the message, but I don't think that's unreasonable to expect
--->
## Changed
#split_message now automatically splits messages on the last ` ` character, instead of just automatically filling out all 2000 characters, because that was causing issues with breaking links or making words commit sepuku.