### PR TITLE
Fix for not rescued NoMethodError on bot kick (#619)

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -883,6 +883,7 @@ module Discordrb
     def delete_guild_member(data)
       server_id = data['guild_id'].to_i
       server = self.server(server_id)
+      return unless server # Server was deleted on GUILD_DELETE. See #619
 
       user_id = data['user']['id'].to_i
       server.delete_member(user_id)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -883,7 +883,7 @@ module Discordrb
     def delete_guild_member(data)
       server_id = data['guild_id'].to_i
       server = self.server(server_id)
-      return unless server # Server was deleted on GUILD_DELETE. See #619
+      return unless server
 
       user_id = data['user']['id'].to_i
       server.delete_member(user_id)


### PR DESCRIPTION
# Summary

Fix for #619 

---

## Changed
Aborting handling of `GUILD_MEMBER_DELETE` if server not found.