### PR TITLE
Remove plain voice connections

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -315,6 +315,8 @@ module Discordrb
     #   (uses an XSalsa20 stream cipher for encryption and Poly1305 for authentication)
     # @return [Voice::VoiceBot] the initialized bot over which audio data can then be sent.
     def voice_connect(chan, encrypted = true)
+      raise ArgumentError, 'Unencrypted voice connections are no longer supported.' unless encrypted
+
       chan = channel(chan.resolve_id)
       server_id = chan.server.id
       @should_encrypt_voice = encrypted

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -805,7 +805,7 @@ module Discordrb
       end
 
       debug('Got data, now creating the bot.')
-      @voices[server_id] = Discordrb::Voice::VoiceBot.new(channel, self, token, @session_id, endpoint, true)
+      @voices[server_id] = Discordrb::Voice::VoiceBot.new(channel, self, token, @session_id, endpoint)
     end
 
     # Internal handler for CHANNEL_CREATE

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -319,7 +319,6 @@ module Discordrb
 
       chan = channel(chan.resolve_id)
       server_id = chan.server.id
-      @should_encrypt_voice = encrypted
 
       if @voices[chan.id]
         debug('Voice bot exists already! Destroying it')
@@ -806,7 +805,7 @@ module Discordrb
       end
 
       debug('Got data, now creating the bot.')
-      @voices[server_id] = Discordrb::Voice::VoiceBot.new(channel, self, token, @session_id, endpoint, @should_encrypt_voice)
+      @voices[server_id] = Discordrb::Voice::VoiceBot.new(channel, self, token, @session_id, endpoint, true)
     end
 
     # Internal handler for CHANNEL_CREATE

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -31,6 +31,7 @@ module Discordrb::Voice
   # Represents a UDP connection to a voice server. This connection is used to send the actual audio data.
   class VoiceUDP
     # @return [true, false] whether or not UDP communications are encrypted.
+    # @deprecated Discord no longer supports unencrypted voice communication.
     attr_accessor :encrypted
     alias_method :encrypted?, :encrypted
 

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -22,6 +22,10 @@ module Discordrb::Voice
   # Signifies to Discord that encryption should be used
   ENCRYPTED_MODE = 'xsalsa20_poly1305'
 
+  # Signifies to Discord that no encryption should be used
+  # @deprecated Discord no longer supports unencrypted voice communication.
+  PLAIN_MODE = 'plain'
+
   # Represents a UDP connection to a voice server. This connection is used to send the actual audio data.
   class VoiceUDP
     # @return [true, false] whether or not UDP communications are encrypted.

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -20,6 +20,8 @@ end
 
 module Discordrb::Voice
   # Signifies to Discord that encryption should be used
+  # @deprecated Discord now supports multiple encryption options.
+  # TODO: Resolve replacement for this constant.
   ENCRYPTED_MODE = 'xsalsa20_poly1305'
 
   # Signifies to Discord that no encryption should be used

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -22,9 +22,6 @@ module Discordrb::Voice
   # Signifies to Discord that encryption should be used
   ENCRYPTED_MODE = 'xsalsa20_poly1305'
 
-  # Signifies to Discord that no encryption should be used
-  PLAIN_MODE = 'plain'
-
   # Represents a UDP connection to a voice server. This connection is used to send the actual audio data.
   class VoiceUDP
     # @return [true, false] whether or not UDP communications are encrypted.
@@ -38,6 +35,7 @@ module Discordrb::Voice
     # initialized.
     def initialize
       @socket = UDPSocket.new
+      @encryped = true
     end
 
     # Initializes the UDP socket with data obtained from opcode 2.
@@ -70,8 +68,8 @@ module Discordrb::Voice
       # Header of the audio packet
       header = [0x80, 0x78, sequence, time, @ssrc].pack('CCnNN')
 
-      # Encrypt data, if necessary
-      buf = encrypt_audio(header, buf) if encrypted?
+      # Always encrypt data
+      buf = encrypt_audio(header, buf)
 
       send_packet(header + buf)
     end
@@ -271,9 +269,10 @@ module Discordrb::Voice
 
     private
 
+    # Always encrypted.
     # @return [String] the mode string that signifies whether encryption should be used or not
     def mode
-      @udp.encrypted? ? ENCRYPTED_MODE : PLAIN_MODE
+      ENCRYPTED_MODE
     end
 
     def heartbeat_loop

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -42,7 +42,7 @@ module Discordrb::Voice
     # initialized.
     def initialize
       @socket = UDPSocket.new
-      @encryped = true
+      @encrypted = true
     end
 
     # Initializes the UDP socket with data obtained from opcode 2.

--- a/lib/discordrb/voice/voice_bot.rb
+++ b/lib/discordrb/voice/voice_bot.rb
@@ -100,6 +100,7 @@ module Discordrb::Voice
     end
 
     # @return [true, false] whether audio data sent will be encrypted.
+    # @deprecated Discord no longer supports unencrypted voice communication.
     def encrypted?
       true
     end

--- a/lib/discordrb/voice/voice_bot.rb
+++ b/lib/discordrb/voice/voice_bot.rb
@@ -74,13 +74,12 @@ module Discordrb::Voice
     attr_accessor :volume
 
     # @!visibility private
-    def initialize(channel, bot, token, session, endpoint, encrypted)
+    def initialize(channel, bot, token, session, endpoint)
       @bot = bot
       @channel = channel
 
       @ws = VoiceWS.new(channel, bot, token, session, endpoint)
       @udp = @ws.udp
-      @udp.encrypted = encrypted
 
       @sequence = @time = 0
       @skips = 0
@@ -102,7 +101,7 @@ module Discordrb::Voice
 
     # @return [true, false] whether audio data sent will be encrypted.
     def encrypted?
-      @udp.encrypted?
+      true
     end
 
     # Set the filter volume. This volume is applied as a filter for decoded audio data. It has the advantage that using

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -198,4 +198,11 @@ describe Discordrb::Bot do
       expect(file.original_filename).to eq 'SPOILER_file.txt'
     end
   end
+
+  describe '#voice_connect' do
+    it 'requires encryption' do
+      channel = double(:channel, resolve_id: double)
+      expect { bot.voice_connect(channel, false) }.to raise_error ArgumentError
+    end
+  end
 end


### PR DESCRIPTION
# Summary

Fixes #664 

---
Bot:
- Raises ArgumentError if `voice_connect` is called with `encryption = false`

VoiceBot:
- Removes initialize parameter `encrypted`
- Hardcodes VoiceBot#encrypted? to true

VoiceUDP:
- Always sets `VoiceUDP#encrypted?` to true
- Skips check for `encrypted?` when sending audio
- Removes PLAIN_MODE constant

I'm not sure if `VoiceUDP#encrypted?` and `VoiceBot#encrypted` should be kept at all, since they're hardcoded to be true anyway. Nobody uses those values, right?