### PR TITLE
Add view_server_insights permission

### DIFF
--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -26,7 +26,7 @@ module Discordrb
       16 => :read_message_history, # 65536
       17 => :mention_everyone,     # 131072
       18 => :use_external_emoji,   # 262144
-      # 19                         # 524288
+      19 => :view_server_insights, # 524288
       20 => :connect,              # 1048576
       21 => :speak,                # 2097152
       22 => :mute_members,         # 4194304


### PR DESCRIPTION
# Summary

Add the missing view_server_insights permission (19).
This is mentioned in the Bot Permissions Calculator (`Applications > {Application} > Bot > Bot Permissions`). `view_guild_insights` is currently in testing for [Partnered / Verified guilds](https://support.discordapp.com/hc/en-us/articles/360032807371). 

The permissions integer correctly corresponds to the missing value (`524288`).

![image](https://im-in.the-cute-person.club/hu7BY3V.png)

---

## Added
Declared `Permissions#view_server_insights` as 19.
