### PR TITLE
Emoji fixup

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -478,7 +478,7 @@ module Discordrb
             end
           end
         elsif /(?<animated>^[a]|^${0}):(?<name>\w+):(?<id>\d+)/ =~ mention
-          array_to_return << (emoji(id) || Emoji.new({ 'animated' => !animated.nil?, 'name' => name, 'id' => id }, self, nil))
+          array_to_return << (emoji(id) || Emoji.new({ 'animated' => !animated.nil?, 'name' => name, 'id' => id }, self))
         end
       end
       array_to_return

--- a/lib/discordrb/data/emoji.rb
+++ b/lib/discordrb/data/emoji.rb
@@ -8,18 +8,17 @@ module Discordrb
     # @return [String] the emoji name
     attr_reader :name
 
-    # @return [Server] the server of this emoji
+    # @return [Server,] the server of this emoji
     attr_reader :server
 
-    # @return [Array<Role>] roles this emoji is active for
+    # @return [Array<Role>, nil] roles this emoji is active for
     attr_reader :roles
 
     # @return [true, false] if the emoji is animated
     attr_reader :animated
     alias_method :animated?, :animated
 
-    def initialize(data, bot, server = nil)
-      @bot = bot
+    def initialize(data, server = nil)
       @roles = nil
 
       @name = data['name']

--- a/lib/discordrb/data/emoji.rb
+++ b/lib/discordrb/data/emoji.rb
@@ -18,7 +18,7 @@ module Discordrb
     attr_reader :animated
     alias_method :animated?, :animated
 
-    def initialize(data, bot, server)
+    def initialize(data, bot, server = nil)
       @bot = bot
       @roles = nil
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -525,7 +525,7 @@ module Discordrb
       end
 
       data = JSON.parse(API::Server.add_emoji(@bot.token, @id, image_string, name, roles.map(&:resolve_id), reason))
-      new_emoji = Emoji.new(data)
+      new_emoji = Emoji.new(data, self)
       @emoji[new_emoji.id] = new_emoji
     end
 
@@ -545,7 +545,7 @@ module Discordrb
     def edit_emoji(emoji, name: nil, roles: nil, reason: nil)
       emoji = @emoji[emoji.resolve_id]
       data = JSON.parse(API::Server.edit_emoji(@bot.token, @id, emoji.resolve_id, name || emoji.name, (roles || emoji.roles).map(&:resolve_id), reason))
-      new_emoji = Emoji.new(data)
+      new_emoji = Emoji.new(data, self)
       @emoji[new_emoji.id] = new_emoji
     end
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -870,7 +870,7 @@ module Discordrb
       return if emoji.empty?
 
       emoji.each do |element|
-        new_emoji = Emoji.new(element, @bot, self)
+        new_emoji = Emoji.new(element, self)
         @emoji[new_emoji.id] = new_emoji
       end
     end

--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -14,7 +14,7 @@ module Discordrb::Events
     def initialize(data, bot)
       @bot = bot
 
-      @emoji = Discordrb::Emoji.new(data['emoji'], bot)
+      @emoji = Discordrb::Emoji.new(data['emoji'])
       @user_id = data['user_id'].to_i
       @message_id = data['message_id'].to_i
       @channel_id = data['channel_id'].to_i

--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -14,7 +14,7 @@ module Discordrb::Events
     def initialize(data, bot)
       @bot = bot
 
-      @emoji = Discordrb::Emoji.new(data['emoji'], bot, nil)
+      @emoji = Discordrb::Emoji.new(data['emoji'], bot)
       @user_id = data['user_id'].to_i
       @message_id = data['message_id'].to_i
       @channel_id = data['channel_id'].to_i

--- a/spec/data/emoji_spec.rb
+++ b/spec/data/emoji_spec.rb
@@ -3,12 +3,10 @@
 require 'discordrb'
 
 describe Discordrb::Emoji do
-  let(:bot) { double('bot') }
-
   subject(:emoji) do
     server = double('server', role: double)
 
-    described_class.new(emoji_data, bot, server)
+    described_class.new(emoji_data, server)
   end
 
   fixture :emoji_data, %i[emoji]


### PR DESCRIPTION
## Summary
The `server` param is treated as optional within the Emoji constructor. This PR adds a `nil` default to reflect that. Also fix some issues I introduced when adding server emoji management. That one sure flew under the radar for a while

## Change
`Bot#parse_mentions`
`Emoji#initialize`
`Server#add_emoji`
`Server#edit_emoji`
`Server#process_emoji`
`ReactionEvent#initialize`
