### PR TITLE
Channel docs update

### DIFF
--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -25,7 +25,8 @@ module Discordrb
     # @return [Integer, nil] the ID of the parent channel, if this channel is inside a cateogry
     attr_reader :parent_id
 
-    # @return [Integer] the type of this channel (0: text, 1: private, 2: voice, 3: group)
+    # @return [Integer] the type of this channel
+    # @see TYPES
     attr_reader :type
 
     # @return [Integer, nil] the ID of the owner of the group channel or nil if this is not a group channel.


### PR DESCRIPTION
We're quite a bit behind on this doc string. Add a `@see` directive pointing to the `TYPES` constant to avoid further neglect
