### PR TITLE
Add dnd? method for User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Server#bot_members`, `Server#non_bot_members` ([#626](https://github.com/discordrb/discordrb/pull/626), thanks @flutterflies)
 - `API.get_gateway_bot` ([#632](https://github.com/discordrb/discordrb/pull/632))
 - `Channel#create_webhook` ([#637](https://github.com/discordrb/discordrb/pull/637), thanks @Chew)
+- `User#dnd?` and documentation for other user status methods ([#679](https://github.com/discordrb/discordrb/pull/679), thanks @kaine119)
 
 ### Changed
 

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -166,7 +166,7 @@ module Discordrb
       @discriminator == Message::ZERO_DISCRIM
     end
 
-    %i[offline idle online].each do |e|
+    %i[offline idle online dnd].each do |e|
       define_method(e.to_s + '?') do
         @status.to_sym == e
       end

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -166,6 +166,14 @@ module Discordrb
       @discriminator == Message::ZERO_DISCRIM
     end
 
+    # @!method offline?
+    #   @return [true, false] whether this user is offline.
+    # @!method idle?
+    #   @return [true, false] whether this user is idle.
+    # @!method online?
+    #   @return [true, false] whether this user is online.
+    # @!method dnd?
+    #   @return [true, false] whether this user is set to do not disturb.
     %i[offline idle online dnd].each do |e|
       define_method(e.to_s + '?') do
         @status.to_sym == e


### PR DESCRIPTION
# Summary
Adds a `User#dnd?` method alongside the rest of the `status?` methods. Also adds documentation for each method

---
## Added
* `User#dnd?`
* Documentation for `User#online?`, `offline?`, `idle?` and `dnd?`

## Changed
* Add grouping around the methods above (feel free to revert this before squashing)
