### PR TITLE
Change getc to readpartial

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -594,7 +594,7 @@ module Discordrb
           end
 
           # Get some data from the socket
-          recv_data = @socket.getc
+          recv_data = @socket.readpartial(4096)
 
           # Check if we actually got data
           unless recv_data


### PR DESCRIPTION
# Summary
Change our method of reading data from the gateway to `readpartial` for much greater efficiency.