### PR TITLE
Only save `session_id` for bot voice state

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -770,13 +770,13 @@ module Discordrb
 
     # Internal handler for VOICE_STATE_UPDATE
     def update_voice_state(data)
-      @session_id = data['session_id']
+      user_id = data['user_id'].to_i
+      @session_id = data['session_id'] if user_id == @profile.id
 
       server_id = data['guild_id'].to_i
       server = server(server_id)
       return unless server
 
-      user_id = data['user_id'].to_i
       old_voice_state = server.voice_states[user_id]
       old_channel_id = old_voice_state.voice_channel.id if old_voice_state
 


### PR DESCRIPTION
*Big thanks to @swarley for helping*
# Summary

This PR fixes bug with `session_id` instance variable of `Bot`.

*Some theory maintainers are aware of, but is required for understanding:
`session_id` is string (unique for each user session) which gets send to discord when bot connects to voice channel. Wrong `session_id` will cause Discord to not only not conect you to voice but also close main WS connection:*
```
[ERROR : vws-i @ 2020-01-08 14:00:28.940] VWS error: Session is no longer valid.
[ERROR : vws @ 2020-01-08 14:00:57.417] VWS error: Broken pipe
[WARN : heartbeat @ 2020-01-08 14:01:49.454] Last heartbeat was not acked, so this is a zombie connection! Reconnecting
[ERROR : heartbeat @ 2020-01-08 14:01:49.454] The websocket connection has closed: (no information)
```

Discord sends you `session_id` for every voice state, this is handled in [`update_voice_state` method](https://github.com/discordrb/discordrb/blob/2c2b50e32c055aa8288b34644346a10696d5efa1/lib/discordrb/bot.rb#L772). Currently `session_id` gets updated even if voice state update is not for bot, which is incorrect and can cause in following bug when [connecting to voice](https://discordapp.com/developers/docs/topics/voice-connections#connecting-to-voice):
1. Voice connecting initiated on Server 1
2. Server 1 `update_voice_state` received and `session_id` is saved
3. At Server 2 someone joined voice channel
4. Server 2 `update_voice_state` received **and `session_id` is replaced with new one**
5. Server 1 `update_voice_server` received , but second `session_id` is used instead of correct one => Session is not valid

*From my bot logs:*
```
[2020-01-09 20:45:45 +0300] INFO:     Bot joining channel at guild 207...
[INFO :  @ 2020-01-09 20:45:46.310] Got voice channel: #<Discordrb::Channel:...>
[INFO : websocket @ 2020-01-09 20:45:46.462] Session id updated: "177...". Guild 207...
[INFO : websocket @ 2020-01-09 20:45:46.614] Session id updated: "b8a...". Guild 626...
[INFO : websocket @ 2020-01-09 20:45:46.659] Got data, now creating the bot for guild 207... Session id: "b8a..."
```

---

## Changed

Only update `session_id` when `user_id == bot_id`
