### PR TITLE
Enhance Respondable#send_temporary_message

### DIFF
--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -30,11 +30,13 @@ module Discordrb::Events
       channel.send_embed(message, embed, &block)
     end
 
-    # Sends a temporary message to the channel this message was sent in, right now.
+    # Sends a temporary message to the channel this message was sent in.
     # @param content [String] The content to send. Should not be longer than 2000 characters or it will result in an error.
     # @param timeout [Float] The amount of time in seconds after which the message sent will be deleted.
-    def send_temporary_message(content, timeout)
-      channel.send_temporary_message(content, timeout)
+    # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
+    # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
+    def send_temporary_message(content, timeout, tts = false, embed = nil)
+      channel.send_temporary_message(content, timeout, tts, embed)
     end
 
     # Adds a string to be sent after the event has finished execution. Avoids problems with rate limiting because only


### PR DESCRIPTION
Enables embed and tts support in Respondable#send_temporary_message

```rb
bot.message do |event|
  embed = Discordrb::Webhooks::Embed.new ...
  event.send_temporary_message('', 60, embed: embed)
end
```

Closes #693