### PR TITLE
Intents

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -15,6 +15,78 @@ module Discordrb
   # The unix timestamp Discord IDs are based on
   DISCORD_EPOCH = 1_420_070_400_000
 
+  INTENTS = {
+    guilds: 1 << 0,
+    guild_create: 1 << 0,
+    guild_delete: 1 << 0,
+    guild_role_create: 1 << 0,
+    guild_role_update: 1 << 0,
+    guild_role_delete: 1  << 0,
+    channel_create: 1  << 0,
+    channel_update: 1  << 0,
+    channel_delete: 1 << 0,
+    channel_pins_update: 1  << 0,
+
+    guild_members: 1 << 1,
+    guild_member_add: 1 << 1,
+    guild_member_update: 1 << 1,
+    guild_member_remove: 1 << 1,
+
+    guild_bans: 1 << 2,
+    guild_ban_add: 1 << 2,
+    guild_ban_remove: 1 << 2,
+
+    guild_emojis: 1 << 3,        
+    guild_emojis_update: 1 << 3,
+
+    guild_integrations: 1 << 4,
+    guild_integrations_update: 1 << 4,
+
+    guild_webhooks: 1 << 5,
+    webhooks_update: 1 << 5,
+
+    guild_invites: 1 << 6,
+    invite_create: 1 << 6,
+    invite_delete: 1 << 6,
+
+    guild_voice_states: 1 << 7,
+    voice_state_update: 1 << 7,
+
+    guild_presences: 1 << 8,
+    presence_update: 1 << 8,
+
+    guild_messages: 1 << 9,
+    message_create: 1 << 9,
+    message_update: 1 << 9,
+    message_delete: 1 << 9,
+
+    guild_message_reactions: 1 << 10,
+    message_reaction_add: 1 << 10,
+    message_reaction_remove: 1 << 10,
+    message_reaction_remove_all: 1 << 10,
+    message_reaction_remove_emoji: 1 << 10,
+
+    guild_message_typing: 1 << 11,
+    typing_start: 1 << 11,
+
+    direct_messages:  1 << 12,
+    direct_message_channel_create: 1 << 12,
+    direct_message_create: 1 << 12,
+    direct_message_update: 1 << 12,
+    direct_message_delete: 1 << 12,
+
+    direct_message_reactions: 1 << 13,
+    direct_message_reaction_add: 1 << 13,
+    direct_message_reaction_remove: 1 << 13,
+    direct_message_reaction_remove_all: 1 << 13,
+    direct_message_reaction_remove_emoji: 1 << 13,
+
+    direct_message_typing: 1 << 14,
+
+    none: 0,
+    all: (0..14).reduce {|x, y| x |= (1 << y) },
+  }.freeze
+
   # Compares two objects based on IDs - either the objects' IDs are equal, or one object is equal to the other's ID.
   def self.id_compare(one_id, other)
     other.respond_to?(:resolve_id) ? (one_id.resolve_id == other.resolve_id) : (one_id == other)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -106,7 +106,7 @@ module Discordrb
       token: nil, client_id: nil,
       type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
       shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false,
-      compress_mode: :large
+      compress_mode: :large, intents: [:all]
     )
       LOGGER.mode = log_mode
       LOGGER.token = token if redact_token
@@ -142,6 +142,8 @@ module Discordrb
       @current_thread = 0
 
       @status = :online
+
+      @intents = intents.reduce(0) {|sum, intent| sum |= INTENTS[intent] }
     end
 
     # The list of users the bot shares a server with.

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -83,7 +83,9 @@ module Discordrb::Commands
         num_shards: attributes[:num_shards],
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
         ignore_bots: attributes[:ignore_bots],
-        compress_mode: attributes[:compress_mode])
+        compress_mode: attributes[:compress_mode],
+        intents: attributes[:intents]
+      )
 
       @prefix = attributes[:prefix]
       @attributes = {

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -308,7 +308,8 @@ module Discordrb
         token: token,
         properties: properties,
         compress: compress,
-        large_threshold: large_threshold
+        large_threshold: large_threshold,
+        intents: 1 << 9
       }
 
       # Don't include the shard key at all if it is nil as Discord checks for its mere existence

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -143,7 +143,7 @@ module Discordrb
     # @return [true, false] whether or not this gateway should check for heartbeat ACKs.
     attr_accessor :check_heartbeat_acks
 
-    def initialize(bot, token, shard_key = nil, compress_mode = :stream)
+    def initialize(bot, token, shard_key = nil, compress_mode = :stream, intents = INTENTS[:all])
       @token = token
       @bot = bot
 
@@ -155,6 +155,7 @@ module Discordrb
       @check_heartbeat_acks = true
 
       @compress_mode = compress_mode
+      @intents = intents
     end
 
     # Connect to the gateway server in a separate thread
@@ -309,7 +310,7 @@ module Discordrb
         properties: properties,
         compress: compress,
         large_threshold: large_threshold,
-        intents: 1 << 9
+        intents: @intents
       }
 
       # Don't include the shard key at all if it is nil as Discord checks for its mere existence
@@ -715,6 +716,7 @@ module Discordrb
 
         @session = Session.new(data['session_id'])
         @session.sequence = 0
+        @bot.__send__(:notify_ready) if (@intents & INTENTS[:guild_create]).zero?
       when :RESUMED
         # The RESUMED event is received after a successful op 6 (resume). It does nothing except tell the bot the
         # connection is initiated (like READY would). Starting with v5, it doesn't set a new heartbeat interval anymore


### PR DESCRIPTION
# Summary

This adds support for the new intent system. This is a rough first pass for people to test out and review.

```ruby
require 'discordrb'

bot = Discordrb::Commands::CommandBot.new(token: ENV['BOT_TOKEN'], prefix: '.', intents: [:guild_messages])

bot.command(:hello) do |event|
  "hello world!"
end

bot.run
```

This bot would respond to commands in servers but not direct messages for example.

A list of intents can be found under `Discordrb::INTENTS`, or [here](https://github.com/discordapp/discord-api-docs/pull/1307).

Currently there is an issue with the default intent value (all intents) which is also being questioned in the comments of that pull request.

## Added
`Discordrb::INTENTS` - Hash of intent names and their respective values.

## Changed
`Discordrb::Bot#initialize` - add intents kwarg
`Discordrb::Commands::CommandBot#initialize` - add intents kwarg
`Discordrb::Gateway#initialize` - add intents positional

Change to the way that the ready event is fired, since the existing method will not be triggered until the first dispatch if you do not have the `guilds` intent.

