### PR TITLE
Fix PermissionCalculator

### DIFF
--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -185,12 +185,14 @@ module Discordrb
       #   (1) the channel explicitly allows or permits an action for the role and
       #   (2) if the user is allowed to do the action if the channel doesn't specify
       roles_to_check.sort_by(&:position).reduce(false) do |can_act, role|
+        # Actions allowed in any role are always allowed
+        return can_act if can_act
         # Get the override defined for the role on the channel
         channel_allow = permission_overwrite(action, channel, role.id)
         can_act = if channel_allow
                     # If the channel has an override, check whether it is an allow - if yes,
-                    # the user can act, if not, it can't
-                    channel_allow == :allow
+                    # the user can always act
+                    true
                   else
                     # Otherwise defer to the role
                     role.permissions.instance_variable_get("@#{action}") || can_act

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -191,8 +191,8 @@ module Discordrb
         channel_allow = permission_overwrite(action, channel, role.id)
         can_act = if channel_allow
                     # If the channel has an override, check whether it is an allow - if yes,
-                    # the user can always act
-                    true
+                    # the user can act, if not, it can't
+                    channel_allow == :allow
                   else
                     # Otherwise defer to the role
                     role.permissions.instance_variable_get("@#{action}") || can_act

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -187,6 +187,7 @@ module Discordrb
       roles_to_check.sort_by(&:position).reduce(false) do |can_act, role|
         # Actions allowed in any role are always allowed
         return can_act if can_act
+
         # Get the override defined for the role on the channel
         channel_allow = permission_overwrite(action, channel, role.id)
         can_act = if channel_allow


### PR DESCRIPTION
# Summary
Once an action allowed by any role, action is always allowed.

Official permission hierarchy is below.
https://support.discordapp.com/hc/articles/206141927-How-is-the-permission-hierarchy-structured-