### PR TITLE
Dependency chores, now with less EOL!™️

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,14 @@ jobs:
       - run:
           name: Run RSpec
           command: bundle exec rspec
+  test_ruby_27:
+    docker:
+      - image: ruby:2.7-alpine
+    steps:
+      - setup-env
+      - run:
+          name: Run RSpec
+          command: bundle exec rspec
 
   rubocop:
     docker:
@@ -101,6 +109,7 @@ workflows:
     jobs:
       - test_ruby_25
       - test_ruby_26
+      - test_ruby_27
       - rubocop
       - yard
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,6 @@ commands:
             - ./vendor/bundle
 
 jobs:
-  test_ruby_24:
-    docker:
-      - image: ruby:2.4-alpine
-    steps:
-      - setup-env
-      - run:
-          name: Run RSpec
-          command: bundle exec rspec
-
   test_ruby_25:
     docker:
       - image: ruby:2.5-alpine
@@ -108,7 +99,6 @@ jobs:
 workflows:
   test:
     jobs:
-      - test_ruby_24
       - test_ruby_25
       - test_ruby_26
       - rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_mode:
 
 AllCops:
   TargetRubyVersion: 2.4
+  NewCops: enable
 
 # Allow 'Pokémon-style' exception handling
 Lint/RescueException:
@@ -16,7 +17,7 @@ Metrics:
   Enabled: false
 
 # Allow some common and/or obvious short method params
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   AllowedNames:
     - e
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@ AllCops:
   TargetRubyVersion: 2.4
   NewCops: enable
 
+# Disable line length checks
+Layout/LineLength:
+  Enabled: false
+
 # Allow 'Pokémon-style' exception handling
 Lint/RescueException:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,8 @@ inherit_mode:
     - AllowedNames
 
 AllCops:
-  TargetRubyVersion: 2.4
   NewCops: enable
+  TargetRubyVersion: 2.5
 
 # Disable line length checks
 Layout/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.4
   - 2.5
   - 2.6
 before_script:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See also: [Documentation](https://www.rubydoc.info/gems/discordrb), [Tutorials](
 
 ## Dependencies
 
-* Ruby >= 2.4 supported
+* Ruby >= 2.5 supported
 * An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
 > **Note:** RubyInstaller for Ruby versions 2.4+ will install the DevKit as the last step of the installation.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ See also: [Documentation](https://www.rubydoc.info/gems/discordrb), [Tutorials](
 * Ruby >= 2.5 supported
 * An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
-> **Note:** RubyInstaller for Ruby versions 2.4+ will install the DevKit as the last step of the installation.
-
 ### Voice dependencies
 
 This section only applies to you if you want to use voice functionality.

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.0.0'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -33,12 +33,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
-  spec.add_development_dependency 'rspec', '~> 3.8.0'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.74.0'
+  spec.add_development_dependency 'rubocop', '~> 0.80.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
-  spec.add_development_dependency 'simplecov', '~> 0.17.0'
+  spec.add_development_dependency 'simplecov', '~> 0.18.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.80.0'
+  spec.add_development_dependency 'rubocop', '~> 0.82.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'simplecov', '~> 0.18.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.3.0'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.85.0'
+  spec.add_development_dependency 'rubocop', '~> 0.86.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'simplecov', '~> 0.18.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.82.0'
+  spec.add_development_dependency 'rubocop', '~> 0.85.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'simplecov', '~> 0.18.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -474,7 +474,7 @@ module Discordrb
           if server
             array_to_return << server.role(id) unless server.role(id).nil?
           else
-            @servers.values.each do |element|
+            @servers.each_value do |element|
               array_to_return << element.role(id) unless element.role(id).nil?
             end
           end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -478,7 +478,7 @@ module Discordrb
               array_to_return << element.role(id) unless element.role(id).nil?
             end
           end
-        elsif /(?<animated>^[a]|^${0}):(?<name>\w+):(?<id>\d+)/ =~ mention
+        elsif /(?<animated>^a|^${0}):(?<name>\w+):(?<id>\d+)/ =~ mention
           array_to_return << (emoji(id) || Emoji.new({ 'animated' => !animated.nil?, 'name' => name, 'id' => id }, self, nil))
         end
       end

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -220,7 +220,7 @@ module Discordrb
         return [channel(id)]
       end
 
-      @servers.values.each do |server|
+      @servers.each_value do |server|
         server.channels.each do |channel|
           results << channel if channel.name == channel_name && (server_name || server.name) == server.name && (!type || (channel.type == type))
         end

--- a/lib/discordrb/events/channels.rb
+++ b/lib/discordrb/events/channels.rb
@@ -126,10 +126,12 @@ module Discordrb::Events
   class ChannelRecipientEvent < Event
     # @return [Channel] the channel in question.
     attr_reader :channel
+
     delegate :name, :server, :type, :owner_id, :recipients, :topic, :user_limit, :position, :permission_overwrites, to: :channel
 
     # @return [Recipient] the recipient that was added/removed from the group
     attr_reader :recipient
+
     delegate :id, to: :recipient
 
     def initialize(data, bot)

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -443,20 +443,18 @@ module Discordrb
       @heartbeat_thread = Thread.new do
         Thread.current[:discordrb_name] = 'heartbeat'
         loop do
-          begin
-            # Send a heartbeat if heartbeats are active and either no session exists yet, or an existing session is
-            # suspended (e.g. after op7)
-            if (@session && !@session.suspended?) || !@session
-              sleep @heartbeat_interval
-              @bot.raise_heartbeat_event
-              heartbeat
-            else
-              sleep 1
-            end
-          rescue StandardError => e
-            LOGGER.error('An error occurred while heartbeating!')
-            LOGGER.log_exception(e)
+          # Send a heartbeat if heartbeats are active and either no session exists yet, or an existing session is
+          # suspended (e.g. after op7)
+          if (@session && !@session.suspended?) || !@session
+            sleep @heartbeat_interval
+            @bot.raise_heartbeat_event
+            heartbeat
+          else
+            sleep 1
           end
+        rescue StandardError => e
+          LOGGER.error('An error occurred while heartbeating!')
+          LOGGER.log_exception(e)
         end
       end
     end

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -42,6 +42,7 @@ module Discordrb
 
     FLAGS.each do |position, flag|
       attr_reader flag
+
       define_method "can_#{flag}=" do |value|
         new_bits = @bits
         if value


### PR DESCRIPTION
# Summary

Same as #713, but also drops Ruby 2.4 now that it's EOL.

---

## Changed
- Dropped support for Ruby 2.4 (EOL)
- Updated Rake, Rspec, RuboCop, and SimpleCov.
- Appeased the RuboCop
