### PR TITLE
Properly serialize unicode emojis in `Emoji#mention`

### DIFF
--- a/lib/discordrb/data/emoji.rb
+++ b/lib/discordrb/data/emoji.rb
@@ -42,6 +42,8 @@ module Discordrb
 
     # @return [String] the layout to mention it (or have it used) in a message
     def mention
+      return name if id.nil?
+
       "<#{'a' if animated}:#{name}:#{id}>"
     end
 

--- a/spec/data/emoji_spec.rb
+++ b/spec/data/emoji_spec.rb
@@ -22,6 +22,14 @@ describe Discordrb::Emoji do
       end
     end
 
+    context 'with a unicode emoji' do
+      it 'serializes' do
+        allow(emoji).to receive(:id).and_return(nil)
+
+        expect(emoji.mention).to eq 'rubytaco'
+      end
+    end
+
     it 'serializes' do
       expect(emoji.mention).to eq '<:rubytaco:315242245274075157>'
     end


### PR DESCRIPTION
# Summary

Allow `Emoji#mention` to be used for unicode emojis.

---

## Added
Tests for serialization of unicode emojis via `mention`

## Fixed
`Emoji#mention` will return `#name` if `#id` is nil, where it would previously return `<:name:>`

