### PR TITLE
fix: Discordrb::Bot/Cache.server loads a server's channels.

### DIFF
--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -96,11 +96,16 @@ module Discordrb
 
       LOGGER.out("Resolving server #{id}")
       begin
-        response = API::Server.resolve(token, id)
+        data = JSON.parse(
+          API::Server.resolve(token, id)
+        )
+        data['channels'] = JSON.parse(
+          API::Server.channels(token, id)
+        )
       rescue Discordrb::Errors::NoPermission
         return nil
       end
-      server = Server.new(JSON.parse(response), self)
+      server = Server.new(data, self)
       @servers[id] = server
     end
 


### PR DESCRIPTION
# Summary

`Bot.server(id)` does not load a server's channels. While `Server.new` expects channels to be in the data. `Server#process_channels` is private leaving the Bot with no obvious way to set the channels.

Perhaps an older version of the API did send the channels when fetching a server. Now they must be fetched separately. Or perhaps I'm using Bot wrong?

## Changed

`Cache#server` now loads a server's channels.