### PR TITLE
Change reconnection close code to 4000

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -367,7 +367,7 @@ module Discordrb
       @instant_reconnect = true
       @should_reconnect = true
 
-      close
+      close code: 4000
     end
 
     # Sends a resume packet (op 6). This replays all events from a previous point specified by its packet sequence. This
@@ -808,7 +808,7 @@ module Discordrb
       end
     end
 
-    def send(data, type = :text)
+    def send(data, type = :text, code = nil)
       LOGGER.out(data)
 
       unless @handshaked && !@closed
@@ -817,7 +817,7 @@ module Discordrb
       end
 
       # Create the frame we're going to send
-      frame = ::WebSocket::Frame::Outgoing::Client.new(data: data, type: type, version: @handshake.version)
+      frame = ::WebSocket::Frame::Outgoing::Client.new(data: data, type: type, code: code, version: @handshake.version)
 
       # Try to send it
       begin
@@ -829,7 +829,7 @@ module Discordrb
       end
     end
 
-    def close
+    def close(code: nil)
       # If we're already closed, there's no need to do anything - return
       return if @closed
 
@@ -837,7 +837,7 @@ module Discordrb
       @session&.suspend
 
       # Send a close frame (if we can)
-      send nil, :close unless @pipe_broken
+      send nil, :close, code unless @pipe_broken
 
       # We're officially closed, notify the main loop.
       @closed = true


### PR DESCRIPTION
# Summary
As said in discord/discord-api-docs#1472, reconnecting with a close code 1000 seems to be a problem.
Therefore, referring to [Rapptz/discord.py 403651a](https://github.com/Rapptz/discord.py/commit/403651a1440260cb46f42d68a82ee35e193a350d), I changed it to set the close code 4000 when reconnecting.

## Changed
Changed to be able to set `code` for close frame in `Gateway#send` and `Gateway#close`.
Changed to set close code 4000 in `Gateway#reconnect`.
