### PR TITLE
feature: Add an EditorConfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
EditorConfig provides basic project editor configuration standards.
It covers the basics of indention, line endings, character set, and
whitespace trimming. It makes it easier to follow project standards.

Supported editors will automatically honor .editorconfig. Others
will need a plugin.

If a contributor's editor supports EditorConfig, they will
automatically follow the project's standards. If not, there's no harm.

See https://editorconfig.org/