### PR TITLE
docs: Demonstrate proper bot shutdown.

### DIFF
--- a/examples/awaits.rb
+++ b/examples/awaits.rb
@@ -76,7 +76,12 @@ bot.message(content: '!time') do |event|
 end
 
 # Connect to Discord
-bot.run
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end
 
 # For more details about Awaits, see:
 # https://www.rubydoc.info/gems/discordrb/Discordrb/Await

--- a/examples/commands.rb
+++ b/examples/commands.rb
@@ -51,4 +51,10 @@ bot.command :long do |event|
   # Here we don't have to worry about the return value because the `event << line` statement automatically returns nil.
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/eval.rb
+++ b/examples/eval.rb
@@ -19,4 +19,10 @@ bot.command(:eval, help_available: false) do |event, *code|
   end
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/ping.rb
+++ b/examples/ping.rb
@@ -28,4 +28,9 @@ end
 
 # This method call has to be put at the end of your script, it is what makes the bot actually connect to Discord. If you
 # leave it out (try it!) the script will simply stop and the bot will not appear online.
-bot.run
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/ping_with_respond_time.rb
+++ b/examples/ping_with_respond_time.rb
@@ -14,4 +14,10 @@ bot.message(content: 'Ping!') do |event|
   m.edit "Pong! Time taken: #{Time.now - event.timestamp} seconds."
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/pm_send.rb
+++ b/examples/pm_send.rb
@@ -13,4 +13,10 @@ bot.mention do |event|
   event.user.pm('You have mentioned me!')
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/prefix_proc.rb
+++ b/examples/prefix_proc.rb
@@ -69,4 +69,10 @@ bot.command(:roll, description: 'rolls some dice',
   "You rolled: `#{rolls}`, total: `#{sum}`"
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/shutdown.rb
+++ b/examples/shutdown.rb
@@ -15,7 +15,14 @@ bot.command(:exit, help_available: false) do |event|
   break unless event.user.id == 66237334693085184 # Replace number with your ID
 
   bot.send_message(event.channel.id, 'Bot is shutting down')
+  bot.stop
   exit
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end

--- a/examples/voice_send.rb
+++ b/examples/voice_send.rb
@@ -50,4 +50,10 @@ bot.command(:play_dca) do |event|
   voice_bot.play_dca('data/music.dca')
 end
 
-bot.run
+# Connect to Discord
+begin
+  bot.run
+# Disconnect when killed with ctrl-c
+rescue Interrupt
+  bot.stop
+end


### PR DESCRIPTION
This updates all the examples to demonstrate proper shutdown using
`bot.stop` when the process is killed. Or, in the case of the shutdown
example, before exiting.

# Summary

Demonstrate proper bot shutdown procedure in the examples.

@z64 [told me I was not correctly shutting down my bot](https://github.com/discordrb/discordrb/pull/716#issuecomment-621525294), but I'd followed the examples and [wiki](https://github.com/discordrb/discordrb/wiki/Basic-bot-creation) (which has been updated).

## Changed

Updated all the examples to demonstrate proper shutdown using `bot.stop` when the process is killed. Or, in the case of the shutdown example, before exiting.