### PR TITLE
Change discordapp.com links to discord.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Join Discord](https://img.shields.io/badge/discord-join-7289DA.svg)](https://discord.gg/cyK3Hjm)
 # discordrb
 
-An implementation of the [Discord](https://discordapp.com/) API using Ruby.
+An implementation of the [Discord](https://discord.com/) API using Ruby.
 
 ## Quick links to sections
 
@@ -133,7 +133,7 @@ If you've made an open source project on GitHub that uses discordrb, consider ad
 Also included is a webhooks client, which can be used as a separate gem `discordrb-webhooks`. This special client can be used to form requests to Discord webhook URLs in a high-level manner.
 
 - [`discordrb-webhooks` documentation](https://www.rubydoc.info/gems/discordrb-webhooks)
-- [More information about webhooks](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
+- [More information about webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
 - [Embed visualizer tool](https://leovoel.github.io/embed-visualizer/) - Includes a discordrb code generator for forming embeds
 
 ### Usage
@@ -141,7 +141,7 @@ Also included is a webhooks client, which can be used as a separate gem `discord
 ```ruby
 require 'discordrb/webhooks'
 
-WEBHOOK_URL = 'https://discordapp.com/api/webhooks/424070213278105610/yByxDncRvHi02mhKQheviQI2erKkfRRwFcEp0MMBfib1ds6ZHN13xhPZNS2-fJo_ApSw'.freeze
+WEBHOOK_URL = 'https://discord.com/api/webhooks/424070213278105610/yByxDncRvHi02mhKQheviQI2erKkfRRwFcEp0MMBfib1ds6ZHN13xhPZNS2-fJo_ApSw'.freeze
 
 client = Discordrb::Webhooks::Client.new(url: WEBHOOK_URL)
 client.execute do |builder|

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['']
 
   spec.summary       = 'Discord API for Ruby'
-  spec.description   = 'A Ruby implementation of the Discord (https://discordapp.com) API.'
+  spec.description   = 'A Ruby implementation of the Discord (https://discord.com) API.'
   spec.homepage      = 'https://github.com/discordrb/discordrb'
   spec.license       = 'MIT'
 

--- a/examples/ping.rb
+++ b/examples/ping.rb
@@ -8,7 +8,7 @@ require 'discordrb'
 # created bot, and eventually run it.
 #
 # If you don't yet have a token to put in here, you will need to create a bot account here:
-#   https://discordapp.com/developers/applications
+#   https://discord.com/developers/applications
 # If you're wondering about what redirect URIs and RPC origins, you can ignore those for now. If that doesn't satisfy
 # you, look here: https://github.com/discordrb/discordrb/wiki/Redirect-URIs-and-RPC-origins
 # After creating the bot, simply copy the token (*not* the OAuth2 secret) and put it into the

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -9,10 +9,10 @@ require 'discordrb/errors'
 # List of methods representing endpoints in Discord's API
 module Discordrb::API
   # The base URL of the Discord REST API.
-  APIBASE = 'https://discordapp.com/api/v6'
+  APIBASE = 'https://discord.com/api/v6'
 
   # The URL of Discord's CDN
-  CDN_URL = 'https://cdn.discordapp.com'
+  CDN_URL = 'https://cdn.discord.com'
 
   module_function
 

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -5,7 +5,7 @@ module Discordrb::API::Channel
   module_function
 
   # Get a channel's data
-  # https://discordapp.com/developers/docs/resources/channel#get-channel
+  # https://discord.com/developers/docs/resources/channel#get-channel
   def resolve(token, channel_id)
     Discordrb::API.request(
       :channels_cid,
@@ -17,7 +17,7 @@ module Discordrb::API::Channel
   end
 
   # Update a channel's data
-  # https://discordapp.com/developers/docs/resources/channel#modify-channel
+  # https://discord.com/developers/docs/resources/channel#modify-channel
   def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, permission_overwrites = nil, parent_id = nil, rate_limit_per_user = nil, reason = nil)
     data = { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw, parent_id: parent_id, rate_limit_per_user: rate_limit_per_user }
     data[:permission_overwrites] = permission_overwrites unless permission_overwrites.nil?
@@ -34,7 +34,7 @@ module Discordrb::API::Channel
   end
 
   # Delete a channel
-  # https://discordapp.com/developers/docs/resources/channel#deleteclose-channel
+  # https://discord.com/developers/docs/resources/channel#deleteclose-channel
   def delete(token, channel_id, reason = nil)
     Discordrb::API.request(
       :channels_cid,
@@ -47,7 +47,7 @@ module Discordrb::API::Channel
   end
 
   # Get a list of messages from a channel's history
-  # https://discordapp.com/developers/docs/resources/channel#get-channel-messages
+  # https://discord.com/developers/docs/resources/channel#get-channel-messages
   def messages(token, channel_id, amount, before = nil, after = nil, around = nil)
     Discordrb::API.request(
       :channels_cid_messages,
@@ -59,7 +59,7 @@ module Discordrb::API::Channel
   end
 
   # Get a single message from a channel's history by id
-  # https://discordapp.com/developers/docs/resources/channel#get-channel-message
+  # https://discord.com/developers/docs/resources/channel#get-channel-message
   def message(token, channel_id, message_id)
     Discordrb::API.request(
       :channels_cid_messages_mid,
@@ -71,7 +71,7 @@ module Discordrb::API::Channel
   end
 
   # Send a message to a channel
-  # https://discordapp.com/developers/docs/resources/channel#create-message
+  # https://discord.com/developers/docs/resources/channel#create-message
   def create_message(token, channel_id, message, tts = false, embed = nil, nonce = nil)
     Discordrb::API.request(
       :channels_cid_messages_mid,
@@ -90,7 +90,7 @@ module Discordrb::API::Channel
   end
 
   # Send a file as a message to a channel
-  # https://discordapp.com/developers/docs/resources/channel#upload-file
+  # https://discord.com/developers/docs/resources/channel#upload-file
   def upload_file(token, channel_id, file, caption: nil, tts: false)
     Discordrb::API.request(
       :channels_cid_messages_mid,
@@ -103,7 +103,7 @@ module Discordrb::API::Channel
   end
 
   # Edit a message
-  # https://discordapp.com/developers/docs/resources/channel#edit-message
+  # https://discord.com/developers/docs/resources/channel#edit-message
   def edit_message(token, channel_id, message_id, message, mentions = [], embed = nil)
     Discordrb::API.request(
       :channels_cid_messages_mid,
@@ -117,7 +117,7 @@ module Discordrb::API::Channel
   end
 
   # Delete a message
-  # https://discordapp.com/developers/docs/resources/channel#delete-message
+  # https://discord.com/developers/docs/resources/channel#delete-message
   def delete_message(token, channel_id, message_id)
     Discordrb::API.request(
       :channels_cid_messages_mid,
@@ -129,7 +129,7 @@ module Discordrb::API::Channel
   end
 
   # Delete messages in bulk
-  # https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages
+  # https://discord.com/developers/docs/resources/channel#bulk-delete-messages
   def bulk_delete_messages(token, channel_id, messages = [])
     Discordrb::API.request(
       :channels_cid_messages_bulk_delete,
@@ -143,7 +143,7 @@ module Discordrb::API::Channel
   end
 
   # Create a reaction on a message using this client
-  # https://discordapp.com/developers/docs/resources/channel#create-reaction
+  # https://discord.com/developers/docs/resources/channel#create-reaction
   def create_reaction(token, channel_id, message_id, emoji)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -158,7 +158,7 @@ module Discordrb::API::Channel
   end
 
   # Delete this client's own reaction on a message
-  # https://discordapp.com/developers/docs/resources/channel#delete-own-reaction
+  # https://discord.com/developers/docs/resources/channel#delete-own-reaction
   def delete_own_reaction(token, channel_id, message_id, emoji)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -171,7 +171,7 @@ module Discordrb::API::Channel
   end
 
   # Delete another client's reaction on a message
-  # https://discordapp.com/developers/docs/resources/channel#delete-user-reaction
+  # https://discord.com/developers/docs/resources/channel#delete-user-reaction
   def delete_user_reaction(token, channel_id, message_id, emoji, user_id)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -184,7 +184,7 @@ module Discordrb::API::Channel
   end
 
   # Get a list of clients who reacted with a specific reaction on a message
-  # https://discordapp.com/developers/docs/resources/channel#get-reactions
+  # https://discord.com/developers/docs/resources/channel#get-reactions
   def get_reactions(token, channel_id, message_id, emoji, before_id, after_id, limit = 100)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
     query_string = "limit=#{limit}#{"&before=#{before_id}" if before_id}#{"&after=#{after_id}" if after_id}"
@@ -198,7 +198,7 @@ module Discordrb::API::Channel
   end
 
   # Deletes all reactions on a message from all clients
-  # https://discordapp.com/developers/docs/resources/channel#delete-all-reactions
+  # https://discord.com/developers/docs/resources/channel#delete-all-reactions
   def delete_all_reactions(token, channel_id, message_id)
     Discordrb::API.request(
       :channels_cid_messages_mid_reactions,
@@ -210,7 +210,7 @@ module Discordrb::API::Channel
   end
 
   # Update a channels permission for a role or member
-  # https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions
+  # https://discord.com/developers/docs/resources/channel#edit-channel-permissions
   def update_permission(token, channel_id, overwrite_id, allow, deny, type, reason = nil)
     Discordrb::API.request(
       :channels_cid_permissions_oid,
@@ -225,7 +225,7 @@ module Discordrb::API::Channel
   end
 
   # Get a channel's invite list
-  # https://discordapp.com/developers/docs/resources/channel#get-channel-invites
+  # https://discord.com/developers/docs/resources/channel#get-channel-invites
   def invites(token, channel_id)
     Discordrb::API.request(
       :channels_cid_invites,
@@ -237,7 +237,7 @@ module Discordrb::API::Channel
   end
 
   # Create an instant invite from a server or a channel id
-  # https://discordapp.com/developers/docs/resources/channel#create-channel-invite
+  # https://discord.com/developers/docs/resources/channel#create-channel-invite
   def create_invite(token, channel_id, max_age = 0, max_uses = 0, temporary = false, unique = false, reason = nil)
     Discordrb::API.request(
       :channels_cid_invites,
@@ -252,7 +252,7 @@ module Discordrb::API::Channel
   end
 
   # Delete channel permission
-  # https://discordapp.com/developers/docs/resources/channel#delete-channel-permission
+  # https://discord.com/developers/docs/resources/channel#delete-channel-permission
   def delete_permission(token, channel_id, overwrite_id, reason = nil)
     Discordrb::API.request(
       :channels_cid_permissions_oid,
@@ -265,7 +265,7 @@ module Discordrb::API::Channel
   end
 
   # Start typing (needs to be resent every 5 seconds to keep up the typing)
-  # https://discordapp.com/developers/docs/resources/channel#trigger-typing-indicator
+  # https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
   def start_typing(token, channel_id)
     Discordrb::API.request(
       :channels_cid_typing,
@@ -278,7 +278,7 @@ module Discordrb::API::Channel
   end
 
   # Get a list of pinned messages in a channel
-  # https://discordapp.com/developers/docs/resources/channel#get-pinned-messages
+  # https://discord.com/developers/docs/resources/channel#get-pinned-messages
   def pinned_messages(token, channel_id)
     Discordrb::API.request(
       :channels_cid_pins,
@@ -290,7 +290,7 @@ module Discordrb::API::Channel
   end
 
   # Pin a message
-  # https://discordapp.com/developers/docs/resources/channel#add-pinned-channel-message
+  # https://discord.com/developers/docs/resources/channel#add-pinned-channel-message
   def pin_message(token, channel_id, message_id)
     Discordrb::API.request(
       :channels_cid_pins_mid,
@@ -303,7 +303,7 @@ module Discordrb::API::Channel
   end
 
   # Unpin a message
-  # https://discordapp.com/developers/docs/resources/channel#delete-pinned-channel-message
+  # https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message
   def unpin_message(token, channel_id, message_id)
     Discordrb::API.request(
       :channels_cid_pins_mid,
@@ -384,7 +384,7 @@ module Discordrb::API::Channel
   end
 
   # Create a webhook
-  # https://discordapp.com/developers/docs/resources/webhook#create-webhook
+  # https://discord.com/developers/docs/resources/webhook#create-webhook
   def create_webhook(token, channel_id, name, avatar = nil, reason = nil)
     Discordrb::API.request(
       :channels_cid_webhooks,
@@ -399,7 +399,7 @@ module Discordrb::API::Channel
   end
 
   # Get channel webhooks
-  # https://discordapp.com/developers/docs/resources/webhook#get-channel-webhooks
+  # https://discord.com/developers/docs/resources/webhook#get-channel-webhooks
   def webhooks(token, channel_id)
     Discordrb::API.request(
       :channels_cid_webhooks,

--- a/lib/discordrb/api/invite.rb
+++ b/lib/discordrb/api/invite.rb
@@ -5,7 +5,7 @@ module Discordrb::API::Invite
   module_function
 
   # Resolve an invite
-  # https://discordapp.com/developers/docs/resources/invite#get-invite
+  # https://discord.com/developers/docs/resources/invite#get-invite
   def resolve(token, invite_code, counts = true)
     Discordrb::API.request(
       :invite_code,
@@ -17,7 +17,7 @@ module Discordrb::API::Invite
   end
 
   # Delete an invite by code
-  # https://discordapp.com/developers/docs/resources/invite#delete-invite
+  # https://discord.com/developers/docs/resources/invite#delete-invite
   def delete(token, code, reason = nil)
     Discordrb::API.request(
       :invites_code,
@@ -30,7 +30,7 @@ module Discordrb::API::Invite
   end
 
   # Join a server using an invite
-  # https://discordapp.com/developers/docs/resources/invite#accept-invite
+  # https://discord.com/developers/docs/resources/invite#accept-invite
   def accept(token, invite_code)
     Discordrb::API.request(
       :invite_code,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -5,7 +5,7 @@ module Discordrb::API::Server
   module_function
 
   # Create a server
-  # https://discordapp.com/developers/docs/resources/guild#create-guild
+  # https://discord.com/developers/docs/resources/guild#create-guild
   def create(token, name, region = :'eu-central')
     Discordrb::API.request(
       :guilds,
@@ -19,7 +19,7 @@ module Discordrb::API::Server
   end
 
   # Get a server's data
-  # https://discordapp.com/developers/docs/resources/guild#get-guild
+  # https://discord.com/developers/docs/resources/guild#get-guild
   def resolve(token, server_id)
     Discordrb::API.request(
       :guilds_sid,
@@ -31,7 +31,7 @@ module Discordrb::API::Server
   end
 
   # Update a server
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild
+  # https://discord.com/developers/docs/resources/guild#modify-guild
   def update(token, server_id, name, region, icon, afk_channel_id, afk_timeout, splash, default_message_notifications, verification_level, explicit_content_filter, system_channel_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid,
@@ -60,7 +60,7 @@ module Discordrb::API::Server
   end
 
   # Delete a server
-  # https://discordapp.com/developers/docs/resources/guild#delete-guild
+  # https://discord.com/developers/docs/resources/guild#delete-guild
   def delete(token, server_id)
     Discordrb::API.request(
       :guilds_sid,
@@ -72,7 +72,7 @@ module Discordrb::API::Server
   end
 
   # Get a server's channels list
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-channels
+  # https://discord.com/developers/docs/resources/guild#get-guild-channels
   def channels(token, server_id)
     Discordrb::API.request(
       :guilds_sid_channels,
@@ -84,7 +84,7 @@ module Discordrb::API::Server
   end
 
   # Create a channel
-  # https://discordapp.com/developers/docs/resources/guild#create-guild-channel
+  # https://discord.com/developers/docs/resources/guild#create-guild-channel
   def create_channel(token, server_id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, position, reason = nil)
     Discordrb::API.request(
       :guilds_sid_channels,
@@ -99,7 +99,7 @@ module Discordrb::API::Server
   end
 
   # Update a channels position
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions
+  # https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
   def update_channel_positions(token, server_id, positions)
     Discordrb::API.request(
       :guilds_sid_channels,
@@ -113,7 +113,7 @@ module Discordrb::API::Server
   end
 
   # Get a member's data
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-member
+  # https://discord.com/developers/docs/resources/guild#get-guild-member
   def resolve_member(token, server_id, user_id)
     Discordrb::API.request(
       :guilds_sid_members_uid,
@@ -125,7 +125,7 @@ module Discordrb::API::Server
   end
 
   # Gets members from the server
-  # https://discordapp.com/developers/docs/resources/guild#list-guild-members
+  # https://discord.com/developers/docs/resources/guild#list-guild-members
   def resolve_members(token, server_id, limit, after = nil)
     Discordrb::API.request(
       :guilds_sid_members,
@@ -137,7 +137,7 @@ module Discordrb::API::Server
   end
 
   # Update a user properties
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-member
+  # https://discord.com/developers/docs/resources/guild#modify-guild-member
   def update_member(token, server_id, user_id, nick: nil, roles: nil, mute: nil, deaf: nil, channel_id: nil, reason: nil)
     Discordrb::API.request(
       :guilds_sid_members_uid,
@@ -157,7 +157,7 @@ module Discordrb::API::Server
   end
 
   # Remove user from server
-  # https://discordapp.com/developers/docs/resources/guild#remove-guild-member
+  # https://discord.com/developers/docs/resources/guild#remove-guild-member
   def remove_member(token, server_id, user_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_uid,
@@ -171,7 +171,7 @@ module Discordrb::API::Server
   end
 
   # Get a server's banned users
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-bans
+  # https://discord.com/developers/docs/resources/guild#get-guild-bans
   def bans(token, server_id)
     Discordrb::API.request(
       :guilds_sid_bans,
@@ -183,7 +183,7 @@ module Discordrb::API::Server
   end
 
   # Ban a user from a server and delete their messages from the last message_days days
-  # https://discordapp.com/developers/docs/resources/guild#create-guild-ban
+  # https://discord.com/developers/docs/resources/guild#create-guild-ban
   def ban_user(token, server_id, user_id, message_days, reason = nil)
     reason = URI.encode_www_form_component(reason) if reason
     Discordrb::API.request(
@@ -197,7 +197,7 @@ module Discordrb::API::Server
   end
 
   # Unban a user from a server
-  # https://discordapp.com/developers/docs/resources/guild#remove-guild-ban
+  # https://discord.com/developers/docs/resources/guild#remove-guild-ban
   def unban_user(token, server_id, user_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_bans_uid,
@@ -210,7 +210,7 @@ module Discordrb::API::Server
   end
 
   # Get server roles
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
+  # https://discord.com/developers/docs/resources/guild#get-guild-roles
   def roles(token, server_id)
     Discordrb::API.request(
       :guilds_sid_roles,
@@ -225,7 +225,7 @@ module Discordrb::API::Server
   # Permissions are the Discord defaults; allowed: invite creation, reading/sending messages,
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
+  # https://discord.com/developers/docs/resources/guild#get-guild-roles
   def create_role(token, server_id, name, colour, hoist, mentionable, packed_permissions, reason = nil)
     Discordrb::API.request(
       :guilds_sid_roles,
@@ -243,7 +243,7 @@ module Discordrb::API::Server
   # Permissions are the Discord defaults; allowed: invite creation, reading/sending messages,
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
-  # https://discordapp.com/developers/docs/resources/guild#batch-modify-guild-role
+  # https://discord.com/developers/docs/resources/guild#batch-modify-guild-role
   def update_role(token, server_id, role_id, name, colour, hoist = false, mentionable = false, packed_permissions = 104_324_161, reason = nil)
     Discordrb::API.request(
       :guilds_sid_roles_rid,
@@ -258,7 +258,7 @@ module Discordrb::API::Server
   end
 
   # Update role positions
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions
+  # https://discord.com/developers/docs/resources/guild#modify-guild-role-positions
   def update_role_positions(token, server_id, roles)
     Discordrb::API.request(
       :guilds_sid_roles,
@@ -272,7 +272,7 @@ module Discordrb::API::Server
   end
 
   # Delete a role
-  # https://discordapp.com/developers/docs/resources/guild#delete-guild-role
+  # https://discord.com/developers/docs/resources/guild#delete-guild-role
   def delete_role(token, server_id, role_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_roles_rid,
@@ -285,7 +285,7 @@ module Discordrb::API::Server
   end
 
   # Adds a single role to a member
-  # https://discordapp.com/developers/docs/resources/guild#add-guild-member-role
+  # https://discord.com/developers/docs/resources/guild#add-guild-member-role
   def add_member_role(token, server_id, user_id, role_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_uid_roles_rid,
@@ -299,7 +299,7 @@ module Discordrb::API::Server
   end
 
   # Removes a single role from a member
-  # https://discordapp.com/developers/docs/resources/guild#remove-guild-member-role
+  # https://discord.com/developers/docs/resources/guild#remove-guild-member-role
   def remove_member_role(token, server_id, user_id, role_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_uid_roles_rid,
@@ -312,7 +312,7 @@ module Discordrb::API::Server
   end
 
   # Get server prune count
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count
+  # https://discord.com/developers/docs/resources/guild#get-guild-prune-count
   def prune_count(token, server_id, days)
     Discordrb::API.request(
       :guilds_sid_prune,
@@ -324,7 +324,7 @@ module Discordrb::API::Server
   end
 
   # Begin server prune
-  # https://discordapp.com/developers/docs/resources/guild#begin-guild-prune
+  # https://discord.com/developers/docs/resources/guild#begin-guild-prune
   def begin_prune(token, server_id, days, reason = nil)
     Discordrb::API.request(
       :guilds_sid_prune,
@@ -338,7 +338,7 @@ module Discordrb::API::Server
   end
 
   # Get invites from server
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-invites
+  # https://discord.com/developers/docs/resources/guild#get-guild-invites
   def invites(token, server_id)
     Discordrb::API.request(
       :guilds_sid_invites,
@@ -350,7 +350,7 @@ module Discordrb::API::Server
   end
 
   # Gets a server's audit logs
-  # https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log
+  # https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log
   def audit_logs(token, server_id, limit, userid = nil, actiontype = nil, before = nil)
     Discordrb::API.request(
       :guilds_sid_auditlogs,
@@ -362,7 +362,7 @@ module Discordrb::API::Server
   end
 
   # Get server integrations
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-integrations
+  # https://discord.com/developers/docs/resources/guild#get-guild-integrations
   def integrations(token, server_id)
     Discordrb::API.request(
       :guilds_sid_integrations,
@@ -374,7 +374,7 @@ module Discordrb::API::Server
   end
 
   # Create a server integration
-  # https://discordapp.com/developers/docs/resources/guild#create-guild-integration
+  # https://discord.com/developers/docs/resources/guild#create-guild-integration
   def create_integration(token, server_id, type, id)
     Discordrb::API.request(
       :guilds_sid_integrations,
@@ -387,7 +387,7 @@ module Discordrb::API::Server
   end
 
   # Update integration from server
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-integration
+  # https://discord.com/developers/docs/resources/guild#modify-guild-integration
   def update_integration(token, server_id, integration_id, expire_behavior, expire_grace_period, enable_emoticons)
     Discordrb::API.request(
       :guilds_sid_integrations_iid,
@@ -401,7 +401,7 @@ module Discordrb::API::Server
   end
 
   # Delete a server integration
-  # https://discordapp.com/developers/docs/resources/guild#delete-guild-integration
+  # https://discord.com/developers/docs/resources/guild#delete-guild-integration
   def delete_integration(token, server_id, integration_id)
     Discordrb::API.request(
       :guilds_sid_integrations_iid,
@@ -413,7 +413,7 @@ module Discordrb::API::Server
   end
 
   # Sync an integration
-  # https://discordapp.com/developers/docs/resources/guild#sync-guild-integration
+  # https://discord.com/developers/docs/resources/guild#sync-guild-integration
   def sync_integration(token, server_id, integration_id)
     Discordrb::API.request(
       :guilds_sid_integrations_iid_sync,
@@ -426,7 +426,7 @@ module Discordrb::API::Server
   end
 
   # Retrieves a server's embed information
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-embed
+  # https://discord.com/developers/docs/resources/guild#get-guild-embed
   def embed(token, server_id)
     Discordrb::API.request(
       :guilds_sid_embed,
@@ -438,7 +438,7 @@ module Discordrb::API::Server
   end
 
   # Modify a server's embed settings
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-embed
+  # https://discord.com/developers/docs/resources/guild#modify-guild-embed
   def modify_embed(token, server_id, enabled, channel_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_embed,
@@ -453,7 +453,7 @@ module Discordrb::API::Server
   end
 
   # Adds a custom emoji.
-  # https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji
+  # https://discord.com/developers/docs/resources/emoji#create-guild-emoji
   def add_emoji(token, server_id, image, name, roles = [], reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis,
@@ -468,7 +468,7 @@ module Discordrb::API::Server
   end
 
   # Changes an emoji name and/or roles.
-  # https://discordapp.com/developers/docs/resources/emoji#modify-guild-emoji
+  # https://discord.com/developers/docs/resources/emoji#modify-guild-emoji
   def edit_emoji(token, server_id, emoji_id, name, roles = nil, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,
@@ -483,7 +483,7 @@ module Discordrb::API::Server
   end
 
   # Deletes a custom emoji
-  # https://discordapp.com/developers/docs/resources/emoji#delete-guild-emoji
+  # https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
   def delete_emoji(token, server_id, emoji_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,
@@ -507,7 +507,7 @@ module Discordrb::API::Server
   end
 
   # Get server webhooks
-  # https://discordapp.com/developers/docs/resources/webhook#get-guild-webhooks
+  # https://discord.com/developers/docs/resources/webhook#get-guild-webhooks
   def webhooks(token, server_id)
     Discordrb::API.request(
       :guilds_sid_webhooks,
@@ -519,7 +519,7 @@ module Discordrb::API::Server
   end
 
   # Adds a member to a server with an OAuth2 Bearer token that has been granted `guilds.join`
-  # https://discordapp.com/developers/docs/resources/guild#add-guild-member
+  # https://discord.com/developers/docs/resources/guild#add-guild-member
   def add_member(token, server_id, user_id, access_token, nick = nil, roles = [], mute = false, deaf = false)
     Discordrb::API.request(
       :guilds_sid_members_uid,

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -5,7 +5,7 @@ module Discordrb::API::User
   module_function
 
   # Get user data
-  # https://discordapp.com/developers/docs/resources/user#get-user
+  # https://discord.com/developers/docs/resources/user#get-user
   def resolve(token, user_id)
     Discordrb::API.request(
       :users_uid,
@@ -17,7 +17,7 @@ module Discordrb::API::User
   end
 
   # Get profile data
-  # https://discordapp.com/developers/docs/resources/user#get-current-user
+  # https://discord.com/developers/docs/resources/user#get-current-user
   def profile(token)
     Discordrb::API.request(
       :users_me,
@@ -43,7 +43,7 @@ module Discordrb::API::User
   end
 
   # Update user data
-  # https://discordapp.com/developers/docs/resources/user#modify-current-user
+  # https://discord.com/developers/docs/resources/user#modify-current-user
   def update_profile(token, email, password, new_username, avatar, new_password = nil)
     Discordrb::API.request(
       :users_me,
@@ -57,7 +57,7 @@ module Discordrb::API::User
   end
 
   # Get the servers a user is connected to
-  # https://discordapp.com/developers/docs/resources/user#get-current-user-guilds
+  # https://discord.com/developers/docs/resources/user#get-current-user-guilds
   def servers(token)
     Discordrb::API.request(
       :users_me_guilds,
@@ -69,7 +69,7 @@ module Discordrb::API::User
   end
 
   # Leave a server
-  # https://discordapp.com/developers/docs/resources/user#leave-guild
+  # https://discord.com/developers/docs/resources/user#leave-guild
   def leave_server(token, server_id)
     Discordrb::API.request(
       :users_me_guilds_sid,
@@ -81,7 +81,7 @@ module Discordrb::API::User
   end
 
   # Get the DMs for the current user
-  # https://discordapp.com/developers/docs/resources/user#get-user-dms
+  # https://discord.com/developers/docs/resources/user#get-user-dms
   def user_dms(token)
     Discordrb::API.request(
       :users_me_channels,
@@ -93,7 +93,7 @@ module Discordrb::API::User
   end
 
   # Create a DM to another user
-  # https://discordapp.com/developers/docs/resources/user#create-dm
+  # https://discord.com/developers/docs/resources/user#create-dm
   def create_pm(token, recipient_id)
     Discordrb::API.request(
       :users_me_channels,
@@ -107,7 +107,7 @@ module Discordrb::API::User
   end
 
   # Get information about a user's connections
-  # https://discordapp.com/developers/docs/resources/user#get-users-connections
+  # https://discord.com/developers/docs/resources/user#get-users-connections
   def connections(token)
     Discordrb::API.request(
       :users_me_connections,

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -5,7 +5,7 @@ module Discordrb::API::Webhook
   module_function
 
   # Get a webhook
-  # https://discordapp.com/developers/docs/resources/webhook#get-webhook
+  # https://discord.com/developers/docs/resources/webhook#get-webhook
   def webhook(token, webhook_id)
     Discordrb::API.request(
       :webhooks_wid,
@@ -17,7 +17,7 @@ module Discordrb::API::Webhook
   end
 
   # Get a webhook via webhook token
-  # https://discordapp.com/developers/docs/resources/webhook#get-webhook-with-token
+  # https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
   def token_webhook(webhook_token, webhook_id)
     Discordrb::API.request(
       :webhooks_wid,
@@ -28,7 +28,7 @@ module Discordrb::API::Webhook
   end
 
   # Update a webhook
-  # https://discordapp.com/developers/docs/resources/webhook#modify-webhook
+  # https://discord.com/developers/docs/resources/webhook#modify-webhook
   def update_webhook(token, webhook_id, data, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
@@ -43,7 +43,7 @@ module Discordrb::API::Webhook
   end
 
   # Update a webhook via webhook token
-  # https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token
+  # https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token
   def token_update_webhook(webhook_token, webhook_id, data, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
@@ -57,7 +57,7 @@ module Discordrb::API::Webhook
   end
 
   # Deletes a webhook
-  # https://discordapp.com/developers/docs/resources/webhook#delete-webhook
+  # https://discord.com/developers/docs/resources/webhook#delete-webhook
   def delete_webhook(token, webhook_id, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
@@ -70,7 +70,7 @@ module Discordrb::API::Webhook
   end
 
   # Deletes a webhook via webhook token
-  # https://discordapp.com/developers/docs/resources/webhook#delete-webhook-with-token
+  # https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
   def token_delete_webhook(webhook_token, webhook_id, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -283,7 +283,7 @@ module Discordrb
 
       server_id_str = server ? "&guild_id=#{server.id}" : ''
       permission_bits_str = permission_bits ? "&permissions=#{permission_bits}" : ''
-      "https://discordapp.com/oauth2/authorize?&client_id=#{@client_id}#{server_id_str}#{permission_bits_str}&scope=bot"
+      "https://discord.com/oauth2/authorize?&client_id=#{@client_id}#{server_id_str}#{permission_bits_str}&scope=bot"
     end
 
     # @return [Hash<Integer => VoiceBot>] the voice connections this bot currently has, by the server ID to which they are connected.
@@ -432,7 +432,7 @@ module Discordrb
     end
 
     # Creates a new application to do OAuth authorization with. This allows you to use OAuth to authorize users using
-    # Discord. For information how to use this, see the docs: https://discordapp.com/developers/docs/topics/oauth2
+    # Discord. For information how to use this, see the docs: https://discord.com/developers/docs/topics/oauth2
     # @param name [String] What your application should be called.
     # @param redirect_uris [Array<String>] URIs that Discord should redirect your users to after authorizing.
     # @return [Array(String, String)] your applications' client ID and client secret to be used in OAuth authorization.

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -188,7 +188,7 @@ module Discordrb
     #
     #    * An {Invite} object
     #    * The code for an invite
-    #    * A fully qualified invite URL (e.g. `https://discordapp.com/invite/0A37aN7fasF7n83q`)
+    #    * A fully qualified invite URL (e.g. `https://discord.com/invite/0A37aN7fasF7n83q`)
     #    * A short invite URL with protocol (e.g. `https://discord.gg/0A37aN7fasF7n83q`)
     #    * A short invite URL without protocol (e.g. `discord.gg/0A37aN7fasF7n83q`)
     # @return [String] Only the code for the invite.

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -779,7 +779,7 @@ module Discordrb
 
     # @return [String] a URL that a user can use to navigate to this channel in the client
     def link
-      "https://discordapp.com/channels/#{@server&.id || '@me'}/#{@channel.id}"
+      "https://discord.com/channels/#{@server&.id || '@me'}/#{@channel.id}"
     end
 
     alias_method :jump_link, :link

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -291,7 +291,7 @@ module Discordrb
 
     # @return [String] a URL that a user can use to navigate to this message in the client
     def link
-      "https://discordapp.com/channels/#{@server&.id || '@me'}/#{@channel.id}/#{@id}"
+      "https://discord.com/channels/#{@server&.id || '@me'}/#{@channel.id}/#{@id}"
     end
 
     alias_method :jump_link, :link

--- a/lib/discordrb/data/role.rb
+++ b/lib/discordrb/data/role.rb
@@ -134,7 +134,7 @@ module Discordrb
     # one API call.
     #
     # Information on how this bitfield is structured can be found at
-    # https://discordapp.com/developers/docs/topics/permissions.
+    # https://discord.com/developers/docs/topics/permissions.
     # @example Remove all permissions from a role
     #   role.packed = 0
     # @param packed [Integer] A bitfield with the desired permissions value.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -274,7 +274,7 @@ module Discordrb
 
     # Adds a member to this guild that has granted this bot's application an OAuth2 access token
     # with the `guilds.join` scope.
-    # For more information about Discord's OAuth2 implementation, see: https://discordapp.com/developers/docs/topics/oauth2
+    # For more information about Discord's OAuth2 implementation, see: https://discord.com/developers/docs/topics/oauth2
     # @note Your bot must be present in this server, and have permission to create instant invites for this to work.
     # @param user [User, String, Integer] the user, or ID of the user to add to this server
     # @param access_token [String] the OAuth2 Bearer token that has been granted the `guilds.join` scope
@@ -391,7 +391,7 @@ module Discordrb
 
     # @return [String] a URL that a user can use to navigate to this server in the client
     def link
-      "https://discordapp.com/channels/#{@id}"
+      "https://discord.com/channels/#{@id}"
     end
 
     alias_method :jump_link, :link

--- a/lib/discordrb/webhooks/client.rb
+++ b/lib/discordrb/webhooks/client.rb
@@ -64,7 +64,7 @@ module Discordrb::Webhooks
     end
 
     def generate_url(id, token)
-      "https://discordapp.com/api/v6/webhooks/#{id}/#{token}"
+      "https://discord.com/api/v6/webhooks/#{id}/#{token}"
     end
   end
 end

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -55,7 +55,7 @@ describe Discordrb::Message do
       data['channel_id'] = channel_id
 
       message = described_class.new(data, bot)
-      expect(message.link).to eq 'https://discordapp.com/channels/server_id/channel_id/message_id'
+      expect(message.link).to eq 'https://discord.com/channels/server_id/channel_id/message_id'
     end
 
     it 'links to a private message' do
@@ -82,7 +82,7 @@ describe Discordrb::Message do
       data['channel_id'] = channel_id
 
       message = described_class.new(data, bot)
-      expect(message.link).to eq 'https://discordapp.com/channels/@me/channel_id/message_id'
+      expect(message.link).to eq 'https://discord.com/channels/@me/channel_id/message_id'
     end
   end
 end


### PR DESCRIPTION
# Summary

As per the announcement in the Discord Developers server, `discord.com` will be used in place of `discordapp.com`, with enforcement starting November 7th 2020.

![image](https://user-images.githubusercontent.com/822067/81007731-c6e13600-8e1f-11ea-82a1-7ccabf4debbb.png)

I believe these are all the references to the `discordapp` domain, and brief testing shows everything to be functional.