### PR TITLE
Support :help_message attribute in CommandBot

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -27,7 +27,6 @@ module Discordrb::Commands
     # @see Discordrb::Bot#initialize Discordrb::Bot#initialize for other attributes that should be used to create the underlying regular bot.
     # @option attributes [String, Array<String>, #call] :prefix The prefix that should trigger this bot's commands. It
     #   can be:
-    #
     #   * Any string (including the empty string). This has the effect that if a message starts with the prefix, the
     #     prefix will be stripped and the rest of the chain will be parsed as a command chain. Note that it will be
     #     literal - if the prefix is "hi" then the corresponding trigger string for a command called "test" would be
@@ -44,6 +43,7 @@ module Discordrb::Commands
     # @option attributes [Symbol, Array<Symbol>, false] :help_command The name of the command that displays info for
     #   other commands. Use an array if you want to have aliases. Default is "help". If none should be created, use
     #   `false` as the value.
+    # @option attributes [String] :help_message The message that will display above the list of commands.  Default is "**List of commands:**".  If :help_command is set to false, this attribute will be ignored.
     # @option attributes [String] :command_doesnt_exist_message The message that should be displayed if a user attempts
     #   to use a command that does not exist. If none is specified, no message will be displayed. In the message, you
     #   can use the string '%command%' that will be replaced with the name of the command.
@@ -92,6 +92,9 @@ module Discordrb::Commands
 
         # The name of the help command (that displays information to other commands). False if none should exist
         help_command: attributes[:help_command].is_a?(FalseClass) ? nil : (attributes[:help_command] || :help),
+
+        # The message that will display above the list of commands.
+        help_message: attributes[:help_message] || "**List of commands:**",
 
         # The message to display for when a command doesn't exist, %command% to get the command name in question and nil for no message
         # No default value here because it may not be desired behaviour
@@ -172,15 +175,15 @@ module Discordrb::Commands
           end
           case available_commands.length
           when 0..5
-            available_commands.reduce "**List of commands:**\n" do |memo, c|
+            available_commands.reduce "#{@attributes[:help_message]}\n" do |memo, c|
               memo + "**`#{c.name}`**: #{c.attributes[:description] || '*No description available*'}\n"
             end
           when 5..50
-            (available_commands.reduce "**List of commands:**\n" do |memo, c|
+            (available_commands.reduce "#{@attributes[:help_message]}\n" do |memo, c|
               memo + "`#{c.name}`, "
             end)[0..-3]
           else
-            event.user.pm(available_commands.reduce("**List of commands:**\n") { |m, e| m + "`#{e.name}`, " }[0..-3])
+            event.user.pm(available_commands.reduce("#{@attributes[:help_message]}\n") { |m, e| m + "`#{e.name}`, " }[0..-3])
             event.channel.pm? ? '' : 'Sending list in PM!'
           end
         end

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -49,6 +49,12 @@ describe Discordrb::Commands::CommandBot, order: :defined do
         allow(member).to receive(:webhook?) { false }
       end
     end
+    allow(event).to receive(:user) do
+      double('user').tap do |user|
+        allow(user).to receive(:id) { user_id }
+        allow(user).to receive(:webhook?) { false }
+      end
+    end
   end
 
   def append_bot_to_double(event)
@@ -115,6 +121,26 @@ describe Discordrb::Commands::CommandBot, order: :defined do
         result = bot.execute_command(:name, command_event_double, [], false, false)
 
         expect(result).to eq SIMPLE_RESPONSE
+      end
+    end
+  end
+
+  describe ':help_command' do
+    context 'without custom :help_message' do
+      it 'should print the default :help_message' do
+        bot = Discordrb::Commands::CommandBot.new(token: 'token')
+        bot.command(:name) { SIMPLE_RESPONSE }
+        result = bot.execute_command(:help, command_event_double_with_channel(first_channel), [], false, false)
+
+        expect(result).to eq "**List of commands:**\n**`help`**: Shows a list of all the commands available or displays help for a specific command.\n**`name`**: *No description available*\n"
+      end
+
+      it 'should print the custom :help_message' do
+        bot = Discordrb::Commands::CommandBot.new(token: 'token', help_message: "Custom Help Message")
+        bot.command(:name) { SIMPLE_RESPONSE }
+        result = bot.execute_command(:help, command_event_double_with_channel(first_channel), [], false, false)
+
+        expect(result).to eq "Custom Help Message\n**`help`**: Shows a list of all the commands available or displays help for a specific command.\n**`name`**: *No description available*\n"
       end
     end
   end

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -134,7 +134,8 @@ describe Discordrb::Commands::CommandBot, order: :defined do
 
         expect(result).to eq "**List of commands:**\n**`help`**: Shows a list of all the commands available or displays help for a specific command.\n**`name`**: *No description available*\n"
       end
-
+    end
+    context 'with custom :Help_message' do
       it 'should print the custom :help_message' do
         bot = Discordrb::Commands::CommandBot.new(token: 'token', help_message: "Custom Help Message")
         bot.command(:name) { SIMPLE_RESPONSE }


### PR DESCRIPTION
Allow customization of `!help` command text.

Users report they didn't realize after just typing `!help` that they could get more info by typing `!help [command]`

I've added the attribute `:help_message` to the constructor of CommandBot to customize the output of the text when a user enters `!help` (or equivalent help command). 

I use this in my code by passing `help_message: "**List of commands:**\n  *(Type !help [command] for more info)*"`