### PR TITLE
fix: emoji parsing in Message#emoji

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -200,30 +200,18 @@ module Discordrb
       !@webhook_id.nil?
     end
 
-    # @!visibility private
-    # @return [Array<String>] the emoji mentions found in the message
-    def scan_for_emoji
-      emoji = @content.split
-      emoji = emoji.grep(/<(?<animated>a)?:(?<name>\w+):(?<id>\d+)>?/)
-      emoji
-    end
-
     # @return [Array<Emoji>] the emotes that were used/mentioned in this message.
     def emoji
       return if @content.nil?
+      return @emoji unless @emoji.empty?
 
-      emoji = scan_for_emoji
-      emoji.each do |element|
-        @emoji << @bot.parse_mention(element)
-      end
-      @emoji
+      @emoji = @bot.parse_mentions(@content).select { |el| el.is_a? Discordrb::Emoji }
     end
 
     # Check if any emoji were used in this message.
     # @return [true, false] whether or not any emoji were used
     def emoji?
-      emoji = scan_for_emoji
-      return true unless emoji.empty?
+      emoji&.empty?
     end
 
     # Check if any reactions were used in this message.

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -25,6 +25,83 @@ describe Discordrb::Message do
     end
   end
 
+  describe '#emoji' do
+    it 'caches and returns only emojis from the message' do
+      server_id = double(:server_id)
+      channel_id = double(:channel_id)
+      message_id = double(:message_id)
+
+      allow(server_id).to receive(:to_i).and_return(server_id)
+      allow(channel_id).to receive(:to_i).and_return(channel_id)
+      allow(message_id).to receive(:to_i).and_return(message_id)
+
+      allow(message_id).to receive(:to_s).and_return('message_id')
+      allow(server_id).to receive(:to_s).and_return('server_id')
+      allow(channel_id).to receive(:to_s).and_return('channel_id')
+
+      allow(server).to receive(:id).and_return(server_id)
+      allow(channel).to receive(:id).and_return(channel_id)
+      allow(bot).to receive(:server).with(server_id).and_return(server)
+      allow(bot).to receive(:channel).with(channel_id).and_return(channel)
+
+      allow(server).to receive(:member)
+      allow(channel).to receive(:private?)
+      allow(channel).to receive(:text?)
+      allow(bot).to receive(:ensure_user).with message_author
+
+      emoji_a = Discordrb::Emoji.new({ 'name' => 'a', 'id' => 123 }, bot, server)
+      emoji_b = Discordrb::Emoji.new({ 'name' => 'b', 'id' => 456 }, bot, server)
+
+      allow(bot).to receive(:user).with('123').and_return(message_author)
+      allow(bot).to receive(:channel).with('123', server).and_return(channel)
+      allow(bot).to receive(:emoji).with('123').and_return(emoji_a)
+      allow(bot).to receive(:emoji).with('456').and_return(emoji_b)
+      allow(bot).to receive(:parse_mentions).and_return([message_author, channel, emoji_a, emoji_b])
+
+      data = message_data
+      data['id'] = message_id
+      data['guild_id'] = server_id
+      data['channel_id'] = channel_id
+
+      message = described_class.new(data, bot)
+      expect(message.emoji).to eq([emoji_a, emoji_b])
+    end
+
+    it 'calls Bot#parse_mentions once' do
+      server_id = double(:server_id)
+      channel_id = double(:channel_id)
+      message_id = double(:message_id)
+
+      allow(server_id).to receive(:to_i).and_return(server_id)
+      allow(channel_id).to receive(:to_i).and_return(channel_id)
+      allow(message_id).to receive(:to_i).and_return(message_id)
+
+      allow(server).to receive(:id).and_return(server_id)
+      allow(channel).to receive(:id).and_return(channel_id)
+      allow(bot).to receive(:server).with(server_id).and_return(server)
+      allow(bot).to receive(:channel).with(channel_id).and_return(channel)
+
+      allow(server).to receive(:member)
+      allow(channel).to receive(:private?)
+      allow(channel).to receive(:text?)
+      allow(bot).to receive(:ensure_user).with message_author
+
+      emoji_a = Discordrb::Emoji.new({ 'name' => 'a', 'id' => 123 }, bot, server)
+      emoji_b = Discordrb::Emoji.new({ 'name' => 'b', 'id' => 456 }, bot, server)
+
+      allow(bot).to receive(:parse_mentions).once.and_return([emoji_a, emoji_b])
+
+      data = message_data
+      data['id'] = message_id
+      data['guild_id'] = server_id
+      data['channel_id'] = channel_id
+
+      message = described_class.new(data, bot)
+      message.emoji
+      message.emoji
+    end
+  end
+
   describe '#link' do
     it 'links to a server message' do
       server_id = double(:server_id)


### PR DESCRIPTION
Closes issue #723 by fixing where calling `Message#emoji` or `Message#scan_for_emoji` on messages with mentions side-by-side with emoji (no interceding whitespace) would parse incorrectly or even return non-emoji resources.

Reduces the number of calls by `Message#emoji` to `Bot#parse_mentions` from multiple calls dependent on the number of "matched" emojis to once.