### PR TITLE
Close code for reconnect

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -367,7 +367,7 @@ module Discordrb
       @instant_reconnect = true
       @should_reconnect = true
 
-      close
+      close(4000)
     end
 
     # Sends a resume packet (op 6). This replays all events from a previous point specified by its packet sequence. This
@@ -808,7 +808,7 @@ module Discordrb
       end
     end
 
-    def send(data, type = :text)
+    def send(data, type = :text, code = nil)
       LOGGER.out(data)
 
       unless @handshaked && !@closed
@@ -817,7 +817,7 @@ module Discordrb
       end
 
       # Create the frame we're going to send
-      frame = ::WebSocket::Frame::Outgoing::Client.new(data: data, type: type, version: @handshake.version)
+      frame = ::WebSocket::Frame::Outgoing::Client.new(data: data, type: type, version: @handshake.version, code: code)
 
       # Try to send it
       begin
@@ -829,7 +829,7 @@ module Discordrb
       end
     end
 
-    def close
+    def close(code = 1000)
       # If we're already closed, there's no need to do anything - return
       return if @closed
 
@@ -837,7 +837,7 @@ module Discordrb
       @session&.suspend
 
       # Send a close frame (if we can)
-      send nil, :close unless @pipe_broken
+      send nil, :close, code unless @pipe_broken
 
       # We're officially closed, notify the main loop.
       @closed = true


### PR DESCRIPTION
# Summary

Add a close code argument to `Gateway#close` for use during reconnect to preserve our session on resume. 

`websocket-ruby` [does not support sending a 1012 (Service Restart)](https://github.com/imanel/websocket-ruby/blob/master/lib/websocket/frame/handler/handler07.rb#L44) so a 4000 close code was selected.
Surveying other libraries it seems they reconnect using 4000 as well.

## Changed
`Gateway#close` - Added optional `code` argument that defaults to 1000
`Gateway#handle_reconnect` - Now calls `close` with a 4000 close code
`Gateway#send` - Added optional `code` argument for use with close codes
