### PR TITLE
Reaction msg

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -126,6 +126,9 @@ module Discordrb
     # This **event** is raised when somebody reacts to a message.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer] :emoji Matches the ID of the emoji that was reacted with, or its name.
+    # @option attributes [String, Integer, User] :from Matches the user who added the reaction.
+    # @option attributes [String, Integer, Message] :message Matches the message to which the reaction was added.
+    # @option attributes [String, Integer, Channel] :in Matches the channel the reaction was added in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionAddEvent] The event that was raised.
     # @return [ReactionAddEventHandler] The event handler that was registered.
@@ -137,6 +140,9 @@ module Discordrb
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer] :emoji Matches the ID of the emoji that was removed from the reactions, or
     #   its name.
+    # @option attributes [String, Integer, User] :from Matches the user who removed the reaction.
+    # @option attributes [String, Integer, Message] :message Matches the message to which the reaction was removed.
+    # @option attributes [String, Integer, Channel] :in Matches the channel the reaction was removed in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionRemoveEvent] The event that was raised.
     # @return [ReactionRemoveEventHandler] The event handler that was registered.
@@ -146,6 +152,9 @@ module Discordrb
 
     # This **event** is raised when somebody removes all reactions from a message.
     # @param attributes [Hash] The event's attributes.
+    # @option attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Message] :message Matches the message to which the reactions were removed.
+    # @option attributes [String, Integer, Channel] :in Matches the channel the reactions were removed in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionRemoveAllEvent] The event that was raised.
     # @return [ReactionRemoveAllEventHandler] The event handler that was registered.

--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -10,6 +10,8 @@ module Discordrb::Events
 
     # @return [Emoji] the emoji that was reacted with.
     attr_reader :emoji
+
+    # @!visibility private
     attr_reader :message_id
 
     def initialize(data, bot)
@@ -75,6 +77,17 @@ module Discordrb::Events
           else
             a == e
           end
+        end,
+        matches_all(@attributes[:from], event.user) do |a, e|
+          if a.is_a? String
+            a == e.name
+          elsif a.is_a? Integer
+            a == e
+          elsif a == :bot
+            e.current_bot?
+          else
+            a == e
+          end
         end
       ].reduce(true, &:&)
     end
@@ -95,6 +108,9 @@ module Discordrb::Events
   # Event raised when somebody removes all reactions from a message
   class ReactionRemoveAllEvent < Event
     include Respondable
+
+    # @!visibility private
+    attr_reader :message_id
 
     def initialize(data, bot)
       @bot = bot
@@ -121,7 +137,21 @@ module Discordrb::Events
       return false unless event.is_a? ReactionRemoveAllEvent
 
       # No attributes yet as there is no property available on the event that doesn't involve doing a resolution request
-      [].reduce(true, &:&)
+      [
+        matches_all(@attributes[:message], event.message_id) do |a, e|
+          a == e
+        end,
+        matches_all(@attributes[:in], event.channel) do |a, e|
+          if a.is_a? String
+            # Make sure to remove the "#" from channel names in case it was specified
+            a.delete('#') == e.name
+          elsif a.is_a? Integer
+            a == e.id
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
     end
   end
 end

--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -10,6 +10,7 @@ module Discordrb::Events
 
     # @return [Emoji] the emoji that was reacted with.
     attr_reader :emoji
+    attr_reader :message_id
 
     def initialize(data, bot)
       @bot = bot
@@ -60,6 +61,19 @@ module Discordrb::Events
             e.name == a || e.name == a.delete(':') || e.id == a.resolve_id
           else
             e == a
+          end
+        end,
+        matches_all(@attributes[:message], event.message_id) do |a, e|
+          a == e
+        end,
+        matches_all(@attributes[:in], event.channel) do |a, e|
+          if a.is_a? String
+            # Make sure to remove the "#" from channel names in case it was specified
+            a.delete('#') == e.name
+          elsif a.is_a? Integer
+            a == e.id
+          else
+            a == e
           end
         end
       ].reduce(true, &:&)


### PR DESCRIPTION
# Summary

Store `message_id` on `ReactionEvents` to allow for `message` matching. Also add support for `from` and `in` matching.

---

## Added
- `from`, `in`, and `message` matchers for `ReactionAddEvent` and `ReactionRemoveEvent`
- `message` and `in` matchers for `ReactionRemoveAllEvent`
- `message_id` instance variable on `ReactionEvent`
