### PR TITLE
fixup: negate empty? for reactions

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -229,7 +229,7 @@ module Discordrb
     # Check if any reactions were used in this message.
     # @return [true, false] whether or not this message has reactions
     def reactions?
-      @reactions.empty?
+      !@reactions.empty?
     end
 
     # Returns the reactions made by the current bot or user.


### PR DESCRIPTION
# Summary

A change to `Message#reactions?` in 1e9691697f054c56688855a26eb0030d0b127178 forgot to negate the return of `empty?`

---

## Fixed
`Discordrb::Message#reactions?` - invert returned bool