### PR TITLE
Fix type of ServerMemberDeleteEvent#user

### DIFF
--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -84,11 +84,8 @@ module Discordrb::Events
       @user = Discordrb::User.new(data['user'], bot)
     end
 
-    # @!attribute [r] user
-    #   @return [User] the user in question.
-    def user
-      super
-    end
+   # @return [User] the user in question.
+   attr_reader :user
   end
 
   # Event handler for {ServerMemberDeleteEvent}

--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -83,6 +83,12 @@ module Discordrb::Events
     def init_user(data, bot)
       @user = Discordrb::User.new(data['user'], bot)
     end
+
+    # @!attribute [r] user
+    #   @return [User] the user in question.
+    def user
+      super
+    end
   end
 
   # Event handler for {ServerMemberDeleteEvent}

--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -84,8 +84,8 @@ module Discordrb::Events
       @user = Discordrb::User.new(data['user'], bot)
     end
 
-   # @return [User] the user in question.
-   attr_reader :user
+    # @return [User] the user in question.
+    attr_reader :user
   end
 
   # Event handler for {ServerMemberDeleteEvent}


### PR DESCRIPTION
# Summary
`ServerMemberDeleteEvent#user` is inherited from `ServerMemberEvent` - there it says it returns a `Member`, which is wrong in the case of `ServerMemberDeleteEvent`: the user is not a `Member` anymore, they left the server. I tried calling `Member` methods on it in my bot and was getting confused why they wouldn't work - I think this PR would clear up the confusion for other people. 
<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added
Documentation for `ServerMemberDeleteEvent#user` - now it correctly says it returns a `User`.
## Changed

## Deprecated

## Removed

## Fixed
