### PR TITLE
Add a couple more fields to see when inspecting

### DIFF
--- a/lib/discordrb/data/role.rb
+++ b/lib/discordrb/data/role.rb
@@ -173,7 +173,7 @@ module Discordrb
 
     # The inspect method is overwritten to give more useful output
     def inspect
-      "<Role name=#{@name} permissions=#{@permissions.inspect} hoist=#{@hoist} colour=#{@colour.inspect} server=#{@server.inspect}>"
+      "<Role name=#{@name} permissions=#{@permissions.inspect} hoist=#{@hoist} colour=#{@colour.inspect} server=#{@server.inspect} position=#{@position} mentionable=#{@mentionable}>"
     end
 
     private


### PR DESCRIPTION
# Summary
This makes a couple fields visible on #inspect's output.
Specifically `position` and `mentionable`.

A small showing of the affected line, before and after

### Before
* `<Role name=#{@name} permissions=#{@permissions.inspect} hoist=#{@hoist} colour=#{@colour.inspect} server=#{@server.inspect}>`
### After
* `<Role name=#{@name} permissions=#{@permissions.inspect} hoist=#{@hoist} colour=#{@colour.inspect} server=#{@server.inspect} position=#{@position} mentionable=#{@mentionable}>`
<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

## Changed
* added `mentionable` and `position` to the fields that #inspect returns