### PR TITLE
Namespace fixup for circle

### DIFF
--- a/lib/discordrb/voice/sodium.rb
+++ b/lib/discordrb/voice/sodium.rb
@@ -3,7 +3,7 @@
 module Discordrb::Voice
   # @!visibility private
   module Sodium
-    extend FFI::Library
+    extend ::FFI::Library
 
     ffi_lib(['sodium', 'libsodium.so.18', 'libsodium.so.23'])
 

--- a/lib/discordrb/voice/sodium.rb
+++ b/lib/discordrb/voice/sodium.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ffi'
+
 module Discordrb::Voice
   # @!visibility private
   module Sodium


### PR DESCRIPTION
# Summary

For some reason circle has an issue with the scope of `FFI` in `sodium.rb` that isn't reflected locally. This uses an explicit reference to the toplevel namespace as a fix.

---
## Fixed
Reference top level namespace to fix circle