### PR TITLE
Update APIBASE URL to new domain

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -9,7 +9,7 @@ require 'discordrb/errors'
 # List of methods representing endpoints in Discord's API
 module Discordrb::API
   # The base URL of the Discord REST API.
-  APIBASE = 'https://discordapp.com/api/v6'
+  APIBASE = 'https://discord.com/api/v6'
 
   # The URL of Discord's CDN
   CDN_URL = 'https://cdn.discordapp.com'


### PR DESCRIPTION
# Summary

Discord is changing their domain from discordapp.com to discord.com. The new domain is reflected in the API docs and should be used for requests going forward. The cutoff date sent in recent messages to API users is November 7, 2020.

---

## Changed

* Updated the APIBASE constant in the API module.
