### PR TITLE
Add support for `attachment://` in `create_message`

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -72,15 +72,27 @@ module Discordrb::API::Channel
 
   # Send a message to a channel
   # https://discordapp.com/developers/docs/resources/channel#create-message
-  def create_message(token, channel_id, message, tts = false, embed = nil, nonce = nil)
+  # @param attachments [Array<File>, nil] Attachments to use with `attachment://` in embeds. See
+  #   https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
+  def create_message(token, channel_id, message, tts = false, embed = nil, nonce = nil, attachments = nil)
+    body = { content: message, tts: tts, embed: embed, nonce: nonce }
+    body = if attachments
+             files = [*0...attachments.size].zip(attachments).to_h
+             { **files, payload_json: body.to_json }
+           else
+             body.to_json
+           end
+
+    headers = { Authorization: token }
+    headers[:content_type] = :json unless attachments
+
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages",
-      { content: message, tts: tts, embed: embed, nonce: nonce }.to_json,
-      Authorization: token,
-      content_type: :json
+      body,
+      **headers
     )
   rescue RestClient::BadRequest => e
     parsed = JSON.parse(e.response.body)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -364,11 +364,11 @@ module Discordrb
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
     # @return [Message] The message that was sent.
-    def send_message(channel, content, tts = false, embed = nil)
+    def send_message(channel, content, tts = false, embed = nil, attachments = nil)
       channel = channel.resolve_id
       debug("Sending message to #{channel} with content '#{content}'")
 
-      response = API::Channel.create_message(token, channel, content, tts, embed ? embed.to_hash : nil)
+      response = API::Channel.create_message(token, channel, content, tts, embed ? embed.to_hash : nil, nil, attachments)
       Message.new(JSON.parse(response), self)
     end
 

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -338,9 +338,10 @@ module Discordrb
     # @param content [String] The content to send. Should not be longer than 2000 characters or it will result in an error.
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @return [Message] the message that was sent.
-    def send_message(content, tts = false, embed = nil)
-      @bot.send_message(@id, content, tts, embed)
+    def send_message(content, tts = false, embed = nil, attachments = nil)
+      @bot.send_message(@id, content, tts, embed, attachments)
     end
 
     alias_method :send, :send_message
@@ -350,8 +351,9 @@ module Discordrb
     # @param timeout [Float] The amount of time in seconds after which the message sent will be deleted.
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
-    def send_temporary_message(content, timeout, tts = false, embed = nil)
-      @bot.send_temporary_message(@id, content, timeout, tts, embed)
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
+    def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil)
+      @bot.send_temporary_message(@id, content, timeout, tts, embed, attachments)
     end
 
     # Convenience method to send a message with an embed.
@@ -362,13 +364,14 @@ module Discordrb
     #   end
     # @param message [String] The message that should be sent along with the embed. If this is the empty string, only the embed will be shown.
     # @param embed [Discordrb::Webhooks::Embed, nil] The embed to start the building process with, or nil if one should be created anew.
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.
-    def send_embed(message = '', embed = nil)
+    def send_embed(message = '', embed = nil, attachments = nil)
       embed ||= Discordrb::Webhooks::Embed.new
       yield(embed) if block_given?
-      send_message(message, false, embed)
+      send_message(message, false, embed, attachments)
     end
 
     # Sends multiple messages to a channel

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -14,20 +14,22 @@ module Discordrb::Events
     # @param content [String] The message to send to the channel
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @return [Discordrb::Message] the message that was sent
-    def send_message(content, tts = false, embed = nil)
-      channel.send_message(content, tts, embed)
+    def send_message(content, tts = false, embed = nil, attachments = nil)
+      channel.send_message(content, tts, embed, attachments)
     end
 
     # The same as {#send_message}, but yields a {Webhooks::Embed} for easy building of embedded content inside a block.
     # @see Channel#send_embed
     # @param message [String] The message that should be sent along with the embed. If this is the empty string, only the embed will be shown.
     # @param embed [Discordrb::Webhooks::Embed, nil] The embed to start the building process with, or nil if one should be created anew.
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.
-    def send_embed(message = '', embed = nil, &block)
-      channel.send_embed(message, embed, &block)
+    def send_embed(message = '', embed = nil, attachments = nil, &block)
+      channel.send_embed(message, embed, attachments, &block)
     end
 
     # Sends a temporary message to the channel this message was sent in, right now.


### PR DESCRIPTION
# Summary

Adds support for uploading images with a message for reference in an embed via `attachment://filename.png`

---

## Changed
The following methods have had `attachments` added as optional positional arguments

- `API::Channel.create_message`
- `Bot#send_message`
- `Channel#send_message`
- `Channel#send_embed`
- `Channel#send_temporary_message`
- `Events::Respondable#send_message`
- `Events::Respondable#send_embed`