### PR TITLE
Add support for client_status on Users and client_status matching on …

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -157,6 +157,8 @@ module Discordrb
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer, User] :from Matches the user whose status changed.
     # @option attributes [:offline, :idle, :online] :status Matches the status the user has now.
+    # @return attributes [Hash<Symbol, Symbol>] :client_status Matches the current online status (`:online`, `:idle` or `:dnd`) of the user
+    #   on various device types (`:desktop`, `:mobile`, or `:web`). The value will be `nil` when the user is offline or invisible
     # @yield The block is executed when the event is raised.
     # @yieldparam event [PresenceEvent] The event that was raised.
     # @return [PresenceEventHandler] the event handler that was registered.

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -51,6 +51,10 @@ module Discordrb
     # @return [Symbol] the current online status of the user (`:online`, `:offline` or `:idle`)
     attr_reader :status
 
+    # @return [Hash<Symbol, Symbol>] the current online status (`:online`, `:idle` or `:dnd`) of the user
+    #   on various device types (`:desktop`, `:mobile`, or `:web`). The value will be `nil` if the user is offline or invisible.
+    attr_reader :client_status
+
     # @return [String, nil] the game the user is currently playing, or `nil` if none is being played.
     attr_reader :game
 
@@ -74,6 +78,7 @@ module Discordrb
       @bot_account = true if data['bot']
 
       @status = :offline
+      @client_status = process_client_status(data['client_status'])
     end
 
     # Get a user's PM channel or send them a PM
@@ -121,6 +126,7 @@ module Discordrb
     # @!visibility private
     def update_presence(data)
       @status = data['status'].to_sym
+      @client_status = process_client_status(data['client_status'])
 
       if data['game']
         game = data['game']
@@ -164,6 +170,11 @@ module Discordrb
     # @return [true, false] whether this user is a fake user for a webhook message
     def webhook?
       @discriminator == Message::ZERO_DISCRIM
+    end
+
+    # @!visibility private
+    def process_client_status(client_status)
+      (client_status || {}).map { |k, v| [k.to_sym, v.to_sym] }.to_h
     end
 
     # @!method offline?

--- a/lib/discordrb/events/presence.rb
+++ b/lib/discordrb/events/presence.rb
@@ -15,11 +15,16 @@ module Discordrb::Events
     # @return [Symbol] the new status.
     attr_reader :status
 
+    # @return [Hash<Symbol, Symbol>] the current online status (`:online`, `:idle` or `:dnd`) of the user
+    #   on various device types (`:desktop`, `:mobile`, or `:web`). The value will be `nil` if the user is offline or invisible.
+    attr_reader :client_status
+
     def initialize(data, bot)
       @bot = bot
 
       @user = bot.user(data['user']['id'].to_i)
       @status = data['status'].to_sym
+      @client_status = user.client_status
       @server = bot.server(data['guild_id'].to_i)
     end
   end
@@ -105,6 +110,9 @@ module Discordrb::Events
         end,
         matches_all(@attributes[:type], event.type) do |a, e|
           a == e
+        end,
+        matches_all(@attributes[:client_status], event.client_status) do |a, e|
+          e.slice(a.keys) == a
         end
       ].reduce(true, &:&)
     end


### PR DESCRIPTION
# Summary

Add support for viewing the `client_status` field on Users. Also adds support for matching `client_status` in presence events.

```ruby
bot.presence(client_status: { mobile: :online }) do |event|
  puts "Someone got on their phone"
end
```

---

## Added
`User#client_status`
`Events::PresenceEvent#client_status`

## Changed
Added support for `client_status` as an attribute on `EventContainer#presence`
