### PR TITLE
guild members have @everyone role

### DIFF
--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -235,7 +235,7 @@ module Discordrb
     # @note For internal use only.
     # @!visibility private
     def update_roles(role_ids)
-      @roles = []
+      @roles = [@server.role(@server.id)]
       role_ids.each do |id|
         # It is posible for members to have roles that do not exist
         # on the server any longer. See https://github.com/discordrb/discordrb/issues/371

--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -34,7 +34,7 @@ module Discordrb::Events
     end
 
     def init_roles(data, _)
-      @roles = []
+      @roles = [@server.role(@server.id)]
       return unless data['roles']
 
       data['roles'].each do |element|


### PR DESCRIPTION
# Summary

Guild members should have the @everyone role.

---

## Changed
Member class & Members event are initialized with the @everyone role now.