### PR TITLE
Remove warning about 64 bit voice on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ This section only applies to you if you want to use voice functionality.
 * A compiled libopus distribution for your system, anywhere the script can find it. See [here](https://github.com/discordrb/discordrb/wiki/Installing-libopus) for installation instructions.
 * [FFmpeg](https://www.ffmpeg.org/download.html) installed and in your PATH
 
-In addition to this, if you're on Windows and want to use voice functionality, your installed Ruby version **needs to be 32 bit**, as otherwise Opus won't work.
-
 ## Installation
 
 ### With Bundler


### PR DESCRIPTION
The wiki now references prebuilt binaries that include support for 64 bit DLLs, so this warning is not true.