### PR TITLE
Add VoiceServerUpdateEvent

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1195,7 +1195,8 @@ module Discordrb
       when :VOICE_SERVER_UPDATE
         update_voice_server(data)
 
-        # no event as this is irrelevant to users
+        event = VoiceServerUpdateEvent.new(data, self)
+        raise_event(event)
       when :CHANNEL_CREATE
         create_channel(data)
 

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -5,6 +5,7 @@ require 'discordrb/events/typing'
 require 'discordrb/events/lifetime'
 require 'discordrb/events/presence'
 require 'discordrb/events/voice_state_update'
+require 'discordrb/events/voice_server_update'
 require 'discordrb/events/channels'
 require 'discordrb/events/members'
 require 'discordrb/events/roles'
@@ -266,6 +267,16 @@ module Discordrb
     # @return [VoiceStateUpdateEventHandler] the event handler that was registered.
     def voice_state_update(attributes = {}, &block)
       register_event(VoiceStateUpdateEvent, attributes, block)
+    end
+
+    # This **event** is raised when first connecting to a server's voice channel.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, User] :from Matches the server that the update is for.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [VoiceServerUpdateEvent] The event that was raised.
+    # @return [VoiceServerUpdateEventHandler] The event handler that was registered.
+    def voice_server_update(attributes = {}, &block)
+      register(VoiceServerUpdateEvent, attributes, block)
     end
 
     # This **event** is raised when a new user joins a server.

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -276,7 +276,7 @@ module Discordrb
     # @yieldparam event [VoiceServerUpdateEvent] The event that was raised.
     # @return [VoiceServerUpdateEventHandler] The event handler that was registered.
     def voice_server_update(attributes = {}, &block)
-      register(VoiceServerUpdateEvent, attributes, block)
+      register_event(VoiceServerUpdateEvent, attributes, block)
     end
 
     # This **event** is raised when a new user joins a server.

--- a/lib/discordrb/events/voice_server_update.rb
+++ b/lib/discordrb/events/voice_server_update.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  # Event raised when a server's voice server is updating.
+  # Sent when initially connecting to voice and when a voice instance fails
+  # over to a new server.
+  # This event is exposed for use with library agnostic interfaces like telecom and
+  # lavalink.
+  class VoiceServerUpdateEvent < Event
+    # @return [String] The voice connection token
+    attr_reader :token
+
+    # @return [Server] The server this update is for.
+    attr_reader :server
+
+    # @return [String] The voice server host.
+    attr_reader :endpoint
+
+    def initialize(data, bot)
+      @bot = bot
+
+      @token = data['token']
+      @endpoint = data['endpoint']
+      @server = bot.server(data['guild_id'])
+    end
+  end
+
+  # Event handler for VoiceServerUpdateEvent
+  class VoiceServerUpdateEventHandler < EventHandler
+    def matches?(event)
+      return false unless event.is_? VoiceServerUpdateEvent
+
+      [
+        matches_all(@attributes[:from], event.server) do |a, e|
+          a == if a.is_a? String
+                 e.name
+               else
+                 e
+               end
+        end
+      ]
+    end
+  end
+end

--- a/lib/discordrb/events/voice_server_update.rb
+++ b/lib/discordrb/events/voice_server_update.rb
@@ -31,7 +31,7 @@ module Discordrb::Events
   # Event handler for VoiceServerUpdateEvent
   class VoiceServerUpdateEventHandler < EventHandler
     def matches?(event)
-      return false unless event.is_? VoiceServerUpdateEvent
+      return false unless event.is_a? VoiceServerUpdateEvent
 
       [
         matches_all(@attributes[:from], event.server) do |a, e|


### PR DESCRIPTION
# Summary


Expose a `VoiceServerUpdateEvent` that can be used for libraries like [telecom](https://github.com/b1naryth1ef/telecom) and [lavalink](https://github.com/Frederikam/Lavalink).

Previously the event handler was used only internally and had a stub saying that it was not useful for end users, but with an external audio player use case this is not true.

---

## Added
`Events::VoiceServerUpdateEvent` - Event raised by the bot.
`Events::VoiceServerUpdateEventHandler` - Handler created from the container method.
`Container#voice_server_update` - Method to hook into a `VOICE_SERVER_UPDATE` event.
