### PR TITLE
Add invite events

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -18,6 +18,7 @@ require 'discordrb/events/bans'
 require 'discordrb/events/raw'
 require 'discordrb/events/reactions'
 require 'discordrb/events/webhooks'
+require 'discordrb/events/invites'
 
 require 'discordrb/api'
 require 'discordrb/api/channel'
@@ -1075,6 +1076,11 @@ module Discordrb
         id = data['guild_id'].to_i
         server = server(id)
         server.process_chunk(data['members'])
+      when :INVITE_CREATE
+        invite = Invite.new(data, self)
+        raise_event(InviteCreateEvent.new(data, invite, self))
+      when :INVITE_DELETE
+        raise_event(InviteDeleteEvent.new(data, self))
       when :MESSAGE_CREATE
         if ignored?(data['author']['id'].to_i)
           debug("Ignored author with ID #{data['author']['id']}")

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -476,6 +476,30 @@ module Discordrb
     alias_method :direct_message, :pm
     alias_method :dm, :pm
 
+    # This **event** is raised when an invite is created.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, User] :inviter Matches the user that created the invite.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel the invite was created for.
+    # @option attributes [String, Integer, Server] :server Matches the server the invite was created for.
+    # @option attributes [true, false] :temporary Matches whether the invite is temporary or not.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [InviteCreateEvent] The event that was raised.
+    # @return [InviteCreateEventHandler] The event handler that was registered.
+    def invite_create(attributes = {}, &block)
+      register_event(InviteCreateEvent, attributes, block)
+    end
+
+    # This **event** is raised when an invite is deleted.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel the deleted invite was for.
+    # @option attributes [String, Integer, Server] :server Matches the server the deleted invite was for.
+    # @yield The block is executed when the event is raised
+    # @yieldparam event [InviteDeleteEvent] The event that was raised.
+    # @return [InviteDeleteEventHandler] The event handler that was registered.
+    def invite_delete(attributes = {}, &block)
+      register_event(InviteDeleteEvent, attributes, block)
+    end
+
     # This **event** is raised for every dispatch received over the gateway, whether supported by discordrb or not.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Symbol, Regexp] :type Matches the event type of the dispatch.

--- a/lib/discordrb/data/invite.rb
+++ b/lib/discordrb/data/invite.rb
@@ -87,8 +87,18 @@ module Discordrb
     def initialize(data, bot)
       @bot = bot
 
-      @channel = InviteChannel.new(data['channel'], bot)
-      @server = InviteServer.new(data['guild'], bot)
+      @channel = if data['channel_id']
+                   bot.channel(data['channel_id'])
+                 else
+                   @channel = InviteChannel.new(data['channel'], bot)
+                 end
+
+      @server = if data['guild_id']
+                  bot.server(data['guild_id'])
+                else
+                  InviteServer.new(data['guild'], bot)
+                end
+
       @uses = data['uses']
       @inviter = data['inviter'] ? (@bot.user(data['inviter']['id'].to_i) || User.new(data['inviter'], bot)) : nil
       @temporary = data['temporary']

--- a/lib/discordrb/data/invite.rb
+++ b/lib/discordrb/data/invite.rb
@@ -44,10 +44,10 @@ module Discordrb
 
   # A Discord invite to a channel
   class Invite
-    # @return [InviteChannel] the channel this invite references.
+    # @return [InviteChannel, Channel] the channel this invite references.
     attr_reader :channel
 
-    # @return [InviteServer] the server this invite references.
+    # @return [InviteServer, Server] the server this invite references.
     attr_reader :server
 
     # @return [Integer] the amount of uses left on this invite.
@@ -87,10 +87,10 @@ module Discordrb
     def initialize(data, bot)
       @bot = bot
 
-      @channel = if data['channel_id']
+      @channel = if data['channel_id'] || bot.channel
                    bot.channel(data['channel_id'])
                  else
-                   @channel = InviteChannel.new(data['channel'], bot)
+                   InviteChannel.new(data['channel'], bot)
                  end
 
       @server = if data['guild_id']

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -365,6 +365,7 @@ module Discordrb
     def splash_id
       @splash_id ||= JSON.parse(API::Server.resolve(@bot.token, @id))['splash']
     end
+    alias splash_hash splash_id
 
     # @return [String, nil] the splash image URL for the server's VIP invite page.
     #   `nil` if there is no splash image.

--- a/lib/discordrb/events/invites.rb
+++ b/lib/discordrb/events/invites.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Discordrb::Events
+  # Raised when an invite is created.
+  class InviteCreateEvent < Event
+    # @return [Invite] The invite that was created.
+    attr_reader :invite
+
+    # @return [Server, nil] The server the invite was created for.
+    attr_reader :server
+
+    # @return [Channel] The channel the invite was created for.
+    attr_reader :channel
+
+    # @!attribute [r] code
+    #   @return [String] The code for the created invite.
+    #   @see Invite#code
+    # @!attribute [r] created_at
+    #   @return [Time] The time the invite was created at.
+    #   @see Invite#created_at
+    # @!attribute [r] max_age
+    #   @return [Integer] The maximum age of the created invite.
+    #   @see Invite#max_age
+    # @!attribute [r] max_uses
+    #   @return [Integer] The maximum number of uses before the invite expires.
+    #   @see Invite#max_uses
+    # @!attribute [r] temporary
+    #   @return [true, false] Whether or not this invite grants temporary membership.
+    #   @see Invite#temporary
+    # @!attribute [r] inviter
+    #   @return [User] The user that created the invite.
+    #   @see Invite#inviter
+    delegate :code, :created_at, :max_age, :max_uses, :temporary, :inviter, to: :invite
+
+    alias temporary? temporary
+
+    def initialize(data, invite, bot)
+      @bot = bot
+      @invite = invite
+      @channel = bot.channel(data['channel_id'])
+      @server = bot.server(data['guild_id']) if data['guild_id']
+    end
+  end
+
+  # Raised when an invite is deleted.
+  class InviteDeleteEvent < Event
+    # @return [Channel] The channel the deleted invite was for.
+    attr_reader :channel
+
+    # @return [Server, nil] The server the deleted invite was for.
+    attr_reader :server
+
+    # @return [String] The code of the deleted invite.
+    attr_reader :code
+
+    def initialize(data, bot)
+      @bot = bot
+      @channel = bot.channel(data['channel_id'])
+      @server = bot.server(data['guild_id']) if data['guild_id']
+      @code = data['code']
+    end
+  end
+
+  # Event handler for InviteCreateEvent.
+  class InviteCreateEventHandler < EventHandler
+    def matches?(event)
+      return false unless event.is_a? InviteCreateEvent
+
+      [
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a == if a.is_a? String
+                 e.name
+               elsif a.is_a? Integer
+                 e.id
+               else
+                 e
+               end
+        end,
+        matches_all(@attributes[:channel], event.channel) do |a, e|
+          a == if a.is_a? String
+                 e.name
+               elsif a.is_a? Integer
+                 e.id
+               else
+                 e
+               end
+        end,
+        matches_all(@attributes[:temporary], event.temporary?, &:==),
+        matches_all(@attributes[:inviter], event.inviter, &:==)
+      ].reduce(true, &:&)
+    end
+  end
+
+  # Event handler for InviteDeleteEvent
+  class InviteDeleteEventHandler < EventHandler
+    def matches?(event)
+      return false unless event.is_a? InviteDeleteEvent
+
+      [
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a == if a.is_a? String
+                 e.name
+               elsif a.is_a? Integer
+                 e.id
+               else
+                 e
+               end
+        end,
+        matches_all(@attributes[:channel], event.channel) do |a, e|
+          a == if a.is_a? String
+                 e.name
+               elsif a.is_a? Integer
+                 e.id
+               else
+                 e
+               end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Add support for `INVITE_CREATE` and `INVITE_DELETE` events. I'm not a huge fan of how I handle the `channel` and `server` fields, specifically how it changes the `Invite#server/channel` fields into two different degrees of objects. I'm interested to hear feedback in that area.

---

## Added

`InviteCreateEvent`
`InviteCreateEventHandler`
`InviteDeleteEvent`
`InviteDeleteEventHandler`
`EventContainer#invite_create`
`EventContainer#invite_delete`
`Server#splash_hash` - Added to preserve backwards compatibility with invite objects. Alias for `splash`

## Changed
`Invite#server` - Can return a partial (`InviteServer`) or full `Server` object depending on the source of the data.
`Invite#channel` - Can return a partial (`InviteChannel`) or full `Channel` object depending on the source of the data.
