### PR TITLE
REST v8 Update

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -94,9 +94,6 @@ module Discordrb::API
     # Add a custom user agent
     attributes.last[:user_agent] = user_agent if attributes.last.is_a? Hash
 
-    # Specify RateLimit precision
-    attributes.last[:x_ratelimit_precision] = 'millisecond'
-
     # The most recent Discord rate limit requirements require the support of major parameters, where a particular route
     # and major parameter combination (*not* the HTTP method) uniquely identifies a RL bucket.
     key = [key, major_parameter].freeze

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -9,7 +9,7 @@ require 'discordrb/errors'
 # List of methods representing endpoints in Discord's API
 module Discordrb::API
   # The base URL of the Discord REST API.
-  APIBASE = 'https://discordapp.com/api/v6'
+  APIBASE = 'https://discord.com/api/v8'
 
   # The URL of Discord's CDN
   CDN_URL = 'https://cdn.discordapp.com'

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -137,7 +137,7 @@ module Discordrb::API
 
       unless mutex.locked?
         response = JSON.parse(e.response)
-        wait_seconds = response['retry_after'].to_i / 1000.0
+        wait_seconds = response['retry_after'].to_f
         Discordrb::LOGGER.ratelimit("Locking RL mutex (key: #{key}) for #{wait_seconds} seconds due to Discord rate limiting")
         trace("429 #{key.join(' ')}")
 

--- a/lib/discordrb/api/invite.rb
+++ b/lib/discordrb/api/invite.rb
@@ -8,10 +8,10 @@ module Discordrb::API::Invite
   # https://discordapp.com/developers/docs/resources/invite#get-invite
   def resolve(token, invite_code, counts = true)
     Discordrb::API.request(
-      :invite_code,
+      :invites_code,
       nil,
       :get,
-      "#{Discordrb::API.api_base}/invite/#{invite_code}#{counts ? '?with_counts=true' : ''}",
+      "#{Discordrb::API.api_base}/invites/#{invite_code}#{counts ? '?with_counts=true' : ''}",
       Authorization: token
     )
   end
@@ -36,7 +36,7 @@ module Discordrb::API::Invite
       :invite_code,
       nil,
       :post,
-      "#{Discordrb::API.api_base}/invite/#{invite_code}",
+      "#{Discordrb::API.api_base}/invites/#{invite_code}",
       nil,
       Authorization: token
     )

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -425,32 +425,36 @@ module Discordrb::API::Server
     )
   end
 
-  # Retrieves a server's embed information
-  # https://discordapp.com/developers/docs/resources/guild#get-guild-embed
-  def embed(token, server_id)
+  # Retrieves a server's widget information
+  # https://discordapp.com/developers/docs/resources/guild#get-guild-widget
+  def widget(token, server_id)
     Discordrb::API.request(
-      :guilds_sid_embed,
+      :guilds_sid_widget,
       server_id,
       :get,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/embed",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/widget",
       Authorization: token
     )
   end
 
+  alias_method :embed, :widget
+
   # Modify a server's embed settings
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-embed
-  def modify_embed(token, server_id, enabled, channel_id, reason = nil)
+  # https://discordapp.com/developers/docs/resources/guild#modify-guild-widget
+  def modify_widget(token, server_id, enabled, channel_id, reason = nil)
     Discordrb::API.request(
-      :guilds_sid_embed,
+      :guilds_sid_widget,
       server_id,
       :patch,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/embed",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/widget",
       { enabled: enabled, channel_id: channel_id }.to_json,
       Authorization: token,
       'X-Audit-Log-Reason': reason,
       content_type: :json
     )
   end
+
+  alias_method :modify_embed, :modify_widget
 
   # Adds a custom emoji.
   # https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -190,7 +190,7 @@ module Discordrb::API::Server
       :guilds_sid_bans_uid,
       server_id,
       :put,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}&reason=#{reason}",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete_message_days=#{message_days}&reason=#{reason}",
       nil,
       Authorization: token
     )

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -188,7 +188,7 @@ module Discordrb
     #
     #    * An {Invite} object
     #    * The code for an invite
-    #    * A fully qualified invite URL (e.g. `https://discordapp.com/invite/0A37aN7fasF7n83q`)
+    #    * A fully qualified invite URL (e.g. `https://discord.com/invites/0A37aN7fasF7n83q`)
     #    * A short invite URL with protocol (e.g. `https://discord.gg/0A37aN7fasF7n83q`)
     #    * A short invite URL without protocol (e.g. `discord.gg/0A37aN7fasF7n83q`)
     # @return [String] Only the code for the invite.

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -201,6 +201,7 @@ module Discordrb
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ChannelCreateEvent] The event that was raised.
     # @return [ChannelCreateEventHandler] the event handler that was registered.
+    # @note Bots do not receive this event for DM channels.
     def channel_create(attributes = {}, &block)
       register_event(ChannelCreateEvent, attributes, block)
     end

--- a/lib/discordrb/data/audit_logs.rb
+++ b/lib/discordrb/data/audit_logs.rb
@@ -189,8 +189,8 @@ module Discordrb
         @old = Permissions.new(@old) if @old && @key == 'permissions'
         @new = Permissions.new(@new) if @new && @key == 'permissions'
 
-        @old = @old.map { |o| Overwrite.new(o['id'], type: o['type'].to_sym, allow: o['allow'], deny: o['deny']) } if @old && @key == 'permission_overwrites'
-        @new = @new.map { |o| Overwrite.new(o['id'], type: o['type'].to_sym, allow: o['allow'], deny: o['deny']) } if @new && @key == 'permission_overwrites'
+        @old = @old.map { |o| Overwrite.new(o['id'], type: o['type'], allow: o['allow'], deny: o['deny']) } if @old && @key == 'permission_overwrites'
+        @new = @new.map { |o| Overwrite.new(o['id'], type: o['type'], allow: o['allow'], deny: o['deny']) } if @new && @key == 'permission_overwrites'
       end
 
       # @return [Channel, nil] the channel that was previously used in the server widget. Only present if the key for this change is `widget_channel_id`.

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -6,8 +6,8 @@ module Discordrb
   class Overwrite
     # Object types an overwrite can apply to.
     TYPES = {
-      role: 0,
-      member: 1
+      0 => :role,
+      1 => :member
     }.freeze
 
     # @return [Integer] ID of the thing associated with this overwrite type
@@ -36,21 +36,25 @@ module Discordrb
     #
     #   Overwrite.new(role, allow: allow, deny: deny)
     # @example Create an overwrite by ID and permissions bits
-    #   Overwrite.new(120571255635181568, type: Overwrite::TYPES[:member], allow: 1024, deny: 0)
+    #   Overwrite.new(120571255635181568, type: 'member', allow: 1024, deny: 0)
     # @param object [Integer, #id] the ID or object this overwrite is for
-    # @param type [Integer] the type of object this overwrite is for (only required if object is an Integer)
+    # @param type [String, Symbol, Integer] the type of object this overwrite is for (only required if object is an Integer)
     # @param allow [Integer, Permissions] allowed permissions for this overwrite, by bits or a Permissions object
     # @param deny [Integer, Permissions] denied permissions for this overwrite, by bits or a Permissions object
-    # @raise [ArgumentError] if type is not :member or :role
+    # @raise [ArgumentError] if type is not valid.
     def initialize(object = nil, type: nil, allow: 0, deny: 0)
       @id = object.respond_to?(:id) ? object.id : object
 
       @type = if object.is_a?(User) || object.is_a?(Member) || object.is_a?(Recipient) || object.is_a?(Profile)
-                TYPES[:member]
+                :member
               elsif object.is_a? Role
-                TYPES[:role]
+                :role
+              elsif type.is_a?(String) || type.is_a?(Symbol) && TYPES.values.include? type.to_sym
+                type.to_sym
+              elsif TYPES[type]
+                TYPES[type]
               else
-                type
+                raise ArgumentError, "Invalid overwrite type: #{type}"
               end
 
       @allow = allow.is_a?(Permissions) ? allow : Permissions.new(allow)

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -4,10 +4,11 @@ module Discordrb
   # A permissions overwrite, when applied to channels describes additional
   # permissions a member needs to perform certain actions in context.
   class Overwrite
+    # Object types an overwrite can apply to.
     TYPES = {
       role: 0,
       member: 1
-    }
+    }.freeze
 
     # @return [Integer] ID of the thing associated with this overwrite type
     attr_accessor :id

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -4,6 +4,11 @@ module Discordrb
   # A permissions overwrite, when applied to channels describes additional
   # permissions a member needs to perform certain actions in context.
   class Overwrite
+    TYPES = {
+      role: 0,
+      member: 1
+    }
+
     # @return [Integer] ID of the thing associated with this overwrite type
     attr_accessor :id
 
@@ -30,24 +35,19 @@ module Discordrb
     #
     #   Overwrite.new(role, allow: allow, deny: deny)
     # @example Create an overwrite by ID and permissions bits
-    #   Overwrite.new(120571255635181568, type: 'member', allow: 1024, deny: 0)
+    #   Overwrite.new(120571255635181568, type: Overwrite::TYPES[:member], allow: 1024, deny: 0)
     # @param object [Integer, #id] the ID or object this overwrite is for
-    # @param type [String] the type of object this overwrite is for (only required if object is an Integer)
+    # @param type [Integer] the type of object this overwrite is for (only required if object is an Integer)
     # @param allow [Integer, Permissions] allowed permissions for this overwrite, by bits or a Permissions object
     # @param deny [Integer, Permissions] denied permissions for this overwrite, by bits or a Permissions object
     # @raise [ArgumentError] if type is not :member or :role
     def initialize(object = nil, type: nil, allow: 0, deny: 0)
-      if type
-        type = type.to_sym
-        raise ArgumentError, 'Overwrite type must be :member or :role' unless (type != :member) || (type != :role)
-      end
-
       @id = object.respond_to?(:id) ? object.id : object
 
       @type = if object.is_a?(User) || object.is_a?(Member) || object.is_a?(Recipient) || object.is_a?(Profile)
-                :member
+                TYPES[:member]
               elsif object.is_a? Role
-                :role
+                TYPES[:role]
               else
                 type
               end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -188,78 +188,77 @@ module Discordrb
       AuditLogs.new(self, @bot, JSON.parse(API::Server.audit_logs(@bot.token, @id, limit, user, action, before)))
     end
 
-    # Cache @embed
+    # Cache @widget
     # @note For internal use only
     # @!visibility private
-    def cache_embed_data
-      data = JSON.parse(API::Server.embed(@bot.token, @id))
-      @embed_enabled = data['enabled']
-      @embed_channel_id = data['channel_id']
+    def cache_widget_data
+      data = JSON.parse(API::Server.widget(@bot.token, @id))
+      @widget_enabled = data['enabled']
+      @widget_channel_id = data['channel_id']
     end
 
     # @return [true, false] whether or not the server has widget enabled
-    def embed_enabled?
-      cache_embed_data if @embed_enabled.nil?
-      @embed_enabled
+    def widget_enabled?
+      cache_widget_data if @widget_enabled.nil?
+      @widget_enabled
     end
-    alias_method :widget_enabled, :embed_enabled?
-    alias_method :widget?, :embed_enabled?
-    alias_method :embed?, :embed_enabled?
+    alias_method :embed_enabled, :widget_enabled?
+    alias_method :embed?, :widget_enabled?
 
-    # @return [Channel, nil] the channel the server embed will make an invite for.
-    def embed_channel
-      cache_embed_data if @embed_enabled.nil?
-      @bot.channel(@embed_channel_id) if @embed_channel_id
+    # @return [Channel, nil] the channel the server widget will make an invite for.
+    def widget_channel
+      cache_widget_data if @widget_enabled.nil?
+      @bot.channel(@widget_channel_id) if @widget_channel_id
     end
-    alias_method :widget_channel, :embed_channel
+    alias_method :embed_channel, :widget_channel
 
-    # Sets whether this server's embed (widget) is enabled
+    # Sets whether this server's widget (embed) is enabled
     # @param value [true, false]
-    def embed_enabled=(value)
-      modify_embed(value, embed_channel)
+    def widget_enabled=(value)
+      modify_widget(value, widget_channel)
     end
 
-    alias_method :widget_enabled=, :embed_enabled=
+    alias_method :embed_enabled=, :widget_enabled=
 
-    # Sets whether this server's embed (widget) is enabled
+    # Sets whether this server's widget (embed) is enabled
     # @param value [true, false]
     # @param reason [String, nil] the reason to be shown in the audit log for this action
-    def set_embed_enabled(value, reason = nil)
-      modify_embed(value, embed_channel, reason)
+    def set_widget_enabled(value, reason = nil)
+      modify_widget(value, widget_channel, reason)
     end
 
-    alias_method :set_widget_enabled, :set_embed_enabled
+    alias_method :set_embed_enabled, :set_widget_enabled
 
-    # Changes the channel on the server's embed (widget)
-    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
-    def embed_channel=(channel)
-      modify_embed(embed?, channel)
+    # Changes the channel on the server's widget (embed)
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
+    def widget_channel=(channel)
+      modify_widget(widget?, channel)
     end
 
-    alias_method :widget_channel=, :embed_channel=
+    alias_method :embed_channel=, :widget_channel=
 
-    # Changes the channel on the server's embed (widget)
-    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
+    # Changes the channel on the server's widget (embed)
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
     # @param reason [String, nil] the reason to be shown in the audit log for this action
-    def set_embed_channel(channel, reason = nil)
-      modify_embed(embed?, channel, reason)
+    def set_widget_channel(channel, reason = nil)
+      modify_widget(widget?, channel, reason)
     end
 
-    alias_method :set_widget_channel, :set_embed_channel
+    alias_method :set_embed_channel, :set_widget_channel
 
-    # Changes the channel on the server's embed (widget), and sets whether it is enabled.
-    # @param enabled [true, false] whether the embed (widget) is enabled
-    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
+    # Changes the channel on the server's widget (embed), and sets whether it is enabled.
+    # @param enabled [true, false] whether the widget (embed) is enabled
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
     # @param reason [String, nil] the reason to be shown in the audit log for this action
-    def modify_embed(enabled, channel, reason = nil)
-      cache_embed_data if @embed_enabled.nil?
-      channel_id = channel ? channel.resolve_id : @embed_channel_id
-      response = JSON.parse(API::Server.modify_embed(@bot.token, @id, enabled, channel_id, reason))
-      @embed_enabled = response['enabled']
-      @embed_channel_id = response['channel_id']
+    def modify_widget(enabled, channel, reason = nil)
+      cache_widget_data if @widget_enabled.nil?
+      channel_id = channel ? channel.resolve_id : @widget_channel_id
+      response = JSON.parse(API::Server.modify_widget(@bot.token, @id, enabled, channel_id, reason))
+      @widget_enabled = response['enabled']
+      @widget_channel_id = response['channel_id']
     end
 
-    alias_method :modify_widget, :modify_embed
+    alias_method :modify_embed, :modify_widget
 
     # @param include_idle [true, false] Whether to count idle members as online.
     # @param include_bots [true, false] Whether to include bot accounts in the count.
@@ -340,8 +339,8 @@ module Discordrb
     # @return [String, nil] the widget URL to the server that displays the amount of online members in a
     #   stylish way. `nil` if the widget is not enabled.
     def widget_url
-      update_data if @embed_enabled.nil?
-      return unless @embed_enabled
+      update_data if @widget_enabled.nil?
+      return unless @widget_enabled
 
       API.widget_url(@id)
     end
@@ -355,8 +354,8 @@ module Discordrb
     # @return [String, nil] the widget banner URL to the server that displays the amount of online members,
     #   server icon and server name in a stylish way. `nil` if the widget is not enabled.
     def widget_banner_url(style)
-      update_data if @embed_enabled.nil?
-      return unless @embed_enabled
+      update_data if @widget_enabled.nil?
+      return unless @widget_enabled
 
       API.widget_url(@id, style)
     end
@@ -840,12 +839,12 @@ module Discordrb
 
       afk_channel_id = new_data[:afk_channel_id] || new_data['afk_channel_id'] || @afk_channel
       @afk_channel_id = afk_channel_id.nil? ? nil : afk_channel_id.resolve_id
-      embed_channel_id = new_data[:embed_channel_id] || new_data['embed_channel_id'] || @embed_channel
-      @embed_channel_id = embed_channel_id.nil? ? nil : embed_channel_id.resolve_id
+      widget_channel_id = new_data[:widget_channel_id] || new_data['widget_channel_id'] || @widget_channel
+      @widget_channel_id = widget_channel_id.nil? ? nil : widget_channel_id.resolve_id
       system_channel_id = new_data[:system_channel_id] || new_data['system_channel_id'] || @system_channel
       @system_channel_id = system_channel_id.nil? ? nil : system_channel_id.resolve_id
 
-      @embed_enabled = new_data[:embed_enabled] || new_data['embed_enabled']
+      @widget_enabled = new_data[:widget_enabled] || new_data['widget_enabled']
       @splash = new_data[:splash_id] || new_data['splash_id'] || @splash_id
 
       @verification_level = new_data[:verification_level] || new_data['verification_level'] || @verification_level

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -101,7 +101,7 @@ module Discordrb
     #   permission.can_speak = true
     # @example Create a permissions object that could allow/deny read messages, connect, and speak by an array of symbols
     #   Permissions.new [:read_messages, :connect, :speak]
-    # @param bits [Integer, Array<Symbol>] The permission bits that should be set from the beginning, or an array of permission flag symbols
+    # @param bits [Integer, String, Array<Symbol>] The permission bits that should be set from the beginning, or an array of permission flag symbols
     # @param writer [RoleWriter] The writer that should be used to update data when a permission is set.
     def initialize(bits = 0, writer = nil)
       @writer = writer
@@ -109,7 +109,7 @@ module Discordrb
       @bits = if bits.is_a? Array
                 self.class.bits(bits)
               else
-                bits
+                bits.to_i
               end
 
       init_vars

--- a/lib/discordrb/webhooks/client.rb
+++ b/lib/discordrb/webhooks/client.rb
@@ -64,7 +64,7 @@ module Discordrb::Webhooks
     end
 
     def generate_url(id, token)
-      "https://discordapp.com/api/v6/webhooks/#{id}/#{token}"
+      "https://discord.com/api/v8/webhooks/#{id}/#{token}"
     end
   end
 end


### PR DESCRIPTION
# Summary

Updates the REST API to use v8. Still a WIP as the enhanced errors still need to be implemented.

## Added
`Overwrite::TYPES` - Symbol to Integer mapping for the new integer overwrite type.

## Changed
Swapped server embed methods to be referred to as widget internally, and offer embed aliases instead of the opposite.
`Overwrite#initialize` - Allows an Integer to be passed for `type`.
