### PR TITLE
Add migration notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Please make any issues or pull requests over there.**
 
+If you were having issues with voice in discordrb 3.3.0, it now works on current gem version. Please update your gemfile to use `~> 3.4.0`. If you want to use the current main branch, use `github: 'shardlab/discordrb'`.
+
 [![Gem](https://img.shields.io/gem/v/discordrb.svg)](https://rubygems.org/gems/discordrb)
 [![Gem](https://img.shields.io/gem/dt/discordrb.svg)](https://rubygems.org/gems/discordrb)
 [![Build Status](https://travis-ci.org/discordrb/discordrb.svg?branch=master)](https://travis-ci.org/discordrb/discordrb)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This project has moved to [shardlab/discordrb](https://github.com/shardlab/discordrb)!
+
+**Please make any issues or pull requests over there.**
+
 [![Gem](https://img.shields.io/gem/v/discordrb.svg)](https://rubygems.org/gems/discordrb)
 [![Gem](https://img.shields.io/gem/dt/discordrb.svg)](https://rubygems.org/gems/discordrb)
 [![Build Status](https://travis-ci.org/discordrb/discordrb.svg?branch=master)](https://travis-ci.org/discordrb/discordrb)


### PR DESCRIPTION
# Summary

Adds a notice to the top of the README that discordrb has moved to shardlab/discordrb
