### PR TITLE
Allow `CommandBot` `command_doesnt_exist_message` to be a callable

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -44,9 +44,10 @@ module Discordrb::Commands
     # @option attributes [Symbol, Array<Symbol>, false] :help_command The name of the command that displays info for
     #   other commands. Use an array if you want to have aliases. Default is "help". If none should be created, use
     #   `false` as the value.
-    # @option attributes [String] :command_doesnt_exist_message The message that should be displayed if a user attempts
+    # @option attributes [String, #call] :command_doesnt_exist_message The message that should be displayed if a user attempts
     #   to use a command that does not exist. If none is specified, no message will be displayed. In the message, you
-    #   can use the string '%command%' that will be replaced with the name of the command.
+    #   can use the string '%command%' that will be replaced with the name of the command. Anything responding to call
+    #   such as a proc will be called with the event, and is expected to return a String or nil.
     # @option attributes [String] :no_permission_message The message to be displayed when `NoPermission` error is raised.
     # @option attributes [true, false] :spaces_allowed Whether spaces are allowed to occur between the prefix and the
     #   command. Default is false.
@@ -215,7 +216,11 @@ module Discordrb::Commands
                     (command && !command.attributes[:channels].nil?)
 
       unless command
-        event.respond @attributes[:command_doesnt_exist_message].gsub('%command%', name.to_s) if @attributes[:command_doesnt_exist_message]
+        if @attributes[:command_doesnt_exist_message]
+          message = @attributes[:command_doesnt_exist_message]
+          message = message.call(event) if message.respond_to?(:call)
+          event.respond message.gsub('%command%', name.to_s) if message
+        end
         return
       end
       return unless !check_permissions || channels?(event.channel, command.attributes[:channels])

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -119,6 +119,40 @@ describe Discordrb::Commands::CommandBot, order: :defined do
     end
   end
 
+  context 'with :command_doesnt_exist_message attribute' do
+    let(:plain_event) { command_event_double_for_channel(first_channel) }
+
+    context 'as a string' do
+      bot = Discordrb::Commands::CommandBot.new(token: 'token', command_doesnt_exist_message: 'command %command% does not exist!')
+
+      it 'replies with the message including % substitution' do
+        expect(plain_event).to receive(:respond).with('command bleep_blorp does not exist!')
+        result = bot.execute_command(:bleep_blorp, plain_event, [])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'as a lambda' do
+      bot = Discordrb::Commands::CommandBot.new(token: 'token', command_doesnt_exist_message: ->(event) { 'command %command% does not exist in #{event.channel.name} and 1+2=#{1 + 2}' })
+
+      it 'executes the lambda and replies with a message including % substitution' do
+        expect(plain_event).to receive(:respond).with('command bleep_blorp does not exist in test-channel and 1+2=3')
+        result = bot.execute_command(:bleep_blorp, plain_event, [])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with a nil' do
+      bot = Discordrb::Commands::CommandBot.new(token: 'token', command_doesnt_exist_message: ->(_event) { nil })
+
+      it 'does not reply' do
+        expect(plain_event).to_not receive(:respond)
+        result = bot.execute_command(:bleep_blorp, plain_event, [])
+        expect(result).to be_nil
+      end
+    end
+  end
+
   describe '#execute_command', order: :defined do
     context 'with role filter', order: :defined do
       bot = Discordrb::Commands::CommandBot.new(token: 'token', help_available: false)


### PR DESCRIPTION
# Summary

Allows the `CommandBot` `command_doesnt_exist_message:` to be a callable. The behaviour stays the same for existing strings and `nil` passed in, but if instead something that responds to `:call` is passed in, that is first called with the `event`, then the result handled in the same way as above. This includes the `nil` behaviour and the replacing of the `"%command%"` substring.

Example:

```ruby
bot = Discordrb::Commands::CommandBot.new(
  token: token,
  prefix: "!",
  command_doesnt_exist_message: ->(event) {
    "Your command %command% doesn't exist. Have you tried? #{ find_similar_commands(event) }"
  }
)
```

## Added

* `CommandBot` `command_doesnt_exist_message:` can be be a callable.


# Alternative approach?

The other approach I was considering was adding:
```ruby
class CommandBot
  def command_not_found(&block)
    @command_not_found = block
  end
end
```

It would be invoked in the same way when a command is missing, but it would mean that it would be defined like:

```ruby
bot = Discordrb::Commands::CommandBot.new(token: token)
bot.command_not_found do |event|
  "Your command %command% doesn't exist. Have you tried? #{ find_similar_commands(event) }"
end
```

This is more in line with the DSL to define commands and responses, but would mean deprecating the `command_doesnt_exist_message` argument, then bumping the semver version.

I would be happy to implement this approach instead. It's mostly working on a branch.